### PR TITLE
fix(benchmark/demo): measure Zag fairly + drop predicted fall-behind order

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -10,8 +10,8 @@ ranking and the scaling shape are what hold.
 
 > Want to _see_ it instead of read tables? **`pnpm benchmark:demo`** opens a live
 > side-by-side where each engine drives a grid of real per-cell machines under a
-> ramping load — watch them fall behind one by one (XState, then Zag, with Chimba
-> last). See [`demo/`](./demo/README.md).
+> ramping load — watch which panels' backlogs grow as the load climbs. See
+> [`demo/`](./demo/README.md).
 
 ## Running
 

--- a/benchmark/demo/README.md
+++ b/benchmark/demo/README.md
@@ -1,9 +1,10 @@
 # Live demo — engine throughput
 
-The ops/sec tables in [`../README.md`](../README.md) say Chimba UI clears more
-engine work per unit time than XState or Zag. This makes that **visible**: four
-panels, each a grid of real per-cell state machines, fed one ramping change
-stream — and you watch them fall behind one by one.
+The ops/sec tables in [`../README.md`](../README.md) measure how much engine work
+each of Chimba UI, XState, and Zag clears per unit time. This makes that
+**visible**: four panels, each a grid of real per-cell state machines, fed one
+ramping change stream under an equal per-frame budget — and you watch which
+panels' backlogs grow as the load climbs.
 
 ```bash
 pnpm benchmark:demo     # from the repo root
@@ -30,6 +31,13 @@ nothing. This demo is deliberately **engine-bound**, not DOM-bound:
 - **Equal time budget.** Each frame, every panel gets the same few ms to apply
   its queue of pending updates. A cheaper-per-update engine clears more → its
   backlog stays near zero; a costlier one can't keep up and falls behind.
+- **Async engines are measured by completed work, not issued work.** Zag's `send`
+  defers each transition to a microtask, so it does no work synchronously when
+  called. The drain loop accounts for this: for an async engine it awaits a flush
+  so the transitions actually run, and counts an update applied only once it has
+  executed — the same yardstick (real transitions completed under the budget) as
+  the synchronous engines. Without this, Zag's queue would empty for free and its
+  panel would report fictional throughput.
 
 ## What you're watching
 
@@ -40,21 +48,28 @@ nothing. This demo is deliberately **engine-bound**, not DOM-bound:
 | **Zag**                | VanillaMachine per cell · guarded transition + bindable cells |
 | **Plain JS** (control) | no engine — the same guard walk + derive as plain JS          |
 
+> **One asymmetry, disclosed:** Chimba's derived value is a **lazy/memoized
+> `computed`** (recomputes only when its input changes); XState and Zag recompute
+> it eagerly in the transition. Here it's ~neutral — every update changes the input,
+> so all three recompute every update anyway — but it's a genuine model difference,
+> not a thumb on the scale.
+
 The load **ramps automatically** until the engines diverge. Reading the result:
 
 - **`updates/s`** (the blue headline) — how much engine work each cleared under
   the same budget. Higher is better.
 - **`queued`** — the backlog it couldn't keep up with; the panel tints red once
   it's falling behind.
-- The honest signal is the **order they fall behind** as the load climbs: XState
-  first, then Zag, with **Chimba the last engine standing** before the
-  no-engine control. That mirrors the benchmark's throughput ranking — made
-  visible.
+- As the load ramps, an engine whose per-update cost is higher can't clear its
+  queue within the shared budget, so its backlog grows while a cheaper one's stays
+  near zero. Watch the panels diverge and draw your own conclusion — the demo
+  measures, it doesn't assert a winner.
 
-**Plain JS leads, and that's the point of including it:** machine machinery has a
-cost; the question is only how cheap. Chimba is the closest of the three engines
-to bare-metal.
+**Plain JS is the control, and that's the point of including it:** machine
+machinery has a cost; the demo lets you see how much each engine adds over
+bare-metal.
 
 > Disposable, like the rest of the benchmark — a felt demonstration, not a
-> certified measurement. Absolute numbers move with your machine; the ranking and
-> the fall-behind order are what hold.
+> certified measurement. Absolute numbers, and which panels diverge, move with your
+> machine, the workload, and the ramp — run it yourself rather than trust a
+> screenshot.

--- a/benchmark/demo/src/app.tsx
+++ b/benchmark/demo/src/app.tsx
@@ -89,7 +89,7 @@ export function App() {
     }
     const ids = Object.keys(handles.current) as PanelId[]
 
-    const frame = (now: number) => {
+    const frame = async (now: number) => {
       if (!runningRef.current) return
       frames++
 
@@ -101,18 +101,30 @@ export function App() {
 
       const batch = feed.pull(curRate)
       for (const id of ids) handles.current[id]?.enqueue(batch)
+      // Drain each panel under its OWN 2ms wall-clock budget. Awaited (not fired
+      // in parallel) so an async engine's flush resolves before we read its result
+      // — each panel still captures its own t0, so the per-panel budget is intact;
+      // they just don't overlap (same total drain time as the old synchronous loop,
+      // ~panels × budget). A sync engine's drain resolves without yielding.
       for (const id of ids) {
-        const r = handles.current[id]?.drain(DRAIN_BUDGET_MS)
+        const r = await handles.current[id]?.drain(DRAIN_BUDGET_MS)
         if (r) applied[id] += r.applied
       }
+      // Stop may have been pressed during an await — bail before scheduling more.
+      if (!runningRef.current) return
 
-      if (now - lastPaint >= PAINT_EVERY_MS) {
+      // Real wall-clock time AFTER the drains (await advanced it past the frame's
+      // `now` timestamp). Paint/sample/ramp bookkeeping uses this so the windows
+      // reflect actual elapsed time, including each engine's real drain cost.
+      const t = performance.now()
+
+      if (t - lastPaint >= PAINT_EVERY_MS) {
         for (const id of ids) handles.current[id]?.paint()
-        lastPaint = now
+        lastPaint = t
       }
 
-      if (now - lastSample >= 250) {
-        const secs = (now - lastSample) / 1000
+      if (t - lastSample >= 250) {
+        const secs = (t - lastSample) / 1000
         setFps(Math.round(frames / secs))
         const next = zeroStats()
         for (const id of ids) {
@@ -131,13 +143,13 @@ export function App() {
         }
         setStats(next)
         frames = 0
-        lastSample = now
+        lastSample = t
 
         // auto-stop once ALL THREE engines have fallen behind — but give a short
         // grace so their backlogs grow to a representative size before freezing
         if (ENGINE_IDS.every(id => overflowedAt[id] !== null)) {
-          if (allBehindSince === 0) allBehindSince = now
-          else if (now - allBehindSince >= STOP_GRACE_MS) {
+          if (allBehindSince === 0) allBehindSince = t
+          else if (t - allBehindSince >= STOP_GRACE_MS) {
             runningRef.current = false
             cancelAnimationFrame(loop.current)
             setRunning(false)

--- a/benchmark/demo/src/app.tsx
+++ b/benchmark/demo/src/app.tsx
@@ -259,12 +259,21 @@ export function App() {
       <p style={{ margin: '0 0 16px', fontSize: 12, opacity: 0.55, maxWidth: 1000 }}>
         <b>updates/s</b> is the headline — how much engine work each clears under the same{' '}
         {DRAIN_BUDGET_MS}ms/frame budget (higher is better). The moment a panel can't keep up it
-        latches a red <b>fell behind by N</b> flag (the backlog it had stacked up). They tip over
-        one by one. <b>Vanilla</b> is the control (no engine), so it leads; the comparison that
+        latches a red <b>fell behind by N</b> flag (the backlog it had stacked up). Watch the panels
+        diverge as the load ramps. <b>Vanilla</b> is the control (no engine); the comparison that
         matters is Chimba vs XState vs Zag.
       </p>
 
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 12 }}>
+      {/* auto-fit + minmax so the four panels wrap to fewer columns as the
+          viewport narrows (4 → 2 → 1) instead of overflowing past the edge on
+          phones/tablets. Pure CSS grid — no media query needed. */}
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))',
+          gap: 12,
+        }}
+      >
         {PANELS.map(p => {
           const s = stats[p.id]
           const behind = s.overflowedAt !== null

--- a/benchmark/demo/src/engines.ts
+++ b/benchmark/demo/src/engines.ts
@@ -22,6 +22,12 @@ export interface CellEngine {
   update: (index: number, v: number) => void
   paintValue: (index: number) => number
   dispose: () => void
+  // Async engines (Zag) don't run a transition synchronously in `update` — they
+  // defer it to a microtask. `flush` resolves once every `update` issued so far
+  // has ACTUALLY executed, so the demo can measure real transition work under a
+  // wall-clock budget instead of counting `update` calls that merely returned.
+  // Absent ⇒ the engine is fully synchronous (work is done when `update` returns).
+  flush?: () => Promise<void>
 }
 
 // The derived computation every engine performs, so the work is identical —
@@ -175,6 +181,15 @@ export function makeZagEngine(size: number, seed: (i: number) => number): CellEn
     },
     paintValue(i) {
       return cells[i].context.get('out')
+    },
+    // Zag's send() schedules the transition in a microtask (see machine.js:
+    // `send = (e) => queueMicrotask(() => {...transition...})`). Every send issued
+    // before this point enqueued its microtask first, so a single microtask turn
+    // drains them ALL (FIFO, run-to-completion) — verified: 1000 sends ⇒ 1000
+    // transitions after one `await`. No coalescing, no timer latency to taint the
+    // wall-clock measurement.
+    flush() {
+      return Promise.resolve()
     },
     dispose() {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/benchmark/demo/src/panels.tsx
+++ b/benchmark/demo/src/panels.tsx
@@ -34,7 +34,10 @@ const ENGINE_FACTORY: Record<PanelId, (size: number, seed: (i: number) => number
 
 export interface PanelHandle {
   enqueue: (changes: CellChange[]) => void
-  drain: (budgetMs: number) => { applied: number; remaining: number }
+  // Async because an async engine (Zag) must await a flush so its deferred
+  // transitions actually execute before we count them. Sync engines resolve
+  // without ever yielding, so they pay nothing for the async signature.
+  drain: (budgetMs: number) => Promise<{ applied: number; remaining: number }>
   backlog: () => number
   paint: () => void
   /** drop the pending queue and wipe the canvas (Stop = reset) */
@@ -72,14 +75,25 @@ export const Panel = React.forwardRef<PanelHandle, { id: PanelId; side: number; 
     React.useImperativeHandle(ref, () => ({
       enqueue: c => queue.push(c),
       backlog: queue.size,
-      drain(budgetMs) {
+      async drain(budgetMs) {
         const t0 = performance.now()
         let applied = 0
-        // apply in chunks, re-checking the clock; each update is a guarded
-        // transition + computed through the engine (the measured cost)
+        // Apply in chunks, re-checking the wall clock; each update is a guarded
+        // transition + computed through the engine (the measured cost).
+        //
+        // SYNC engines (Chimba/XState/raw, `flush` absent): the work is done when
+        // `update` returns, so we count the chunk immediately — identical to the
+        // original synchronous loop, no yielding.
+        //
+        // ASYNC engines (Zag, `flush` present): `update` only SCHEDULES the
+        // transition, so we await `flush()` to let the chunk's transitions
+        // actually run, and only THEN count them. This measures real transition
+        // work against the same wall-clock budget — not `send()` calls that merely
+        // returned (which is what made the old loop count Zag's work as free).
         while (queue.size() > 0 && performance.now() - t0 < budgetMs) {
           const chunk = queue.take(512)
           for (const c of chunk) engine.update(c.index, c.value)
+          if (engine.flush) await engine.flush()
           applied += chunk.length
         }
         return { applied, remaining: queue.size() }


### PR DESCRIPTION
## The problem

The live demo drove every engine through a **synchronous** per-frame drain and counted an update *applied* the moment `update()` returned. That's valid for Chimba and XState (synchronous `send`), but **Zag's `VanillaMachine.send` defers the entire transition to a `queueMicrotask`** — so inside the 2ms budget Zag did *no* transition work, drained its queue for free, and reported **fictional throughput**.

Verified against Zag's source (`@zag-js/vanilla` `send = (e) => queueMicrotask(() => {...transition...})`) and a probe: **1000 synchronous `send()` calls → 0 transitions executed** until a flush (and no coalescing — all 1000 run after one microtask turn).

The headless suite already excludes Zag from sync ops/sec loops for exactly this reason; the demo silently included it.

## The fix - measure completed work

- **`engines.ts`** — `CellEngine` gains optional `flush(): Promise<void>`. Zag implements it (one microtask turn drains all queued transitions). Sync engines omit it and keep the **exact synchronous path** — no regression.
- **`panels.tsx`** — `drain()` is now async: for an async engine it `await`s `flush()` so the chunk's transitions actually run **before** counting them.
- **`app.tsx`** — the rAF frame loop `await`s each panel's drain (each with its own 2ms budget, no overlap) and refreshes the wall clock afterward for paint/sample/auto-stop.

### Proof
Headless port of the drain loop against the **real** engines, 2ms budget:

| engine | applied / 2ms (before) | applied / 2ms (after) |
| --- | ---: | ---: |
| raw (control) | 20000 | 20000 |
| chimba | real | 1536 |
| **zag** | **~20000 (fake — free drain)** | **1024 (real)** |
| xstate | real | 512 |

## Scope
Engine code and the **headless benchmark tables are untouched** — this is the demo's measurement + the two READMEs' prose only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)