### PR TITLE
feat(bindings): full agnostic vocabulary + payload-accurate normalizers

### DIFF
--- a/packages/core/src/bindings.ts
+++ b/packages/core/src/bindings.ts
@@ -27,6 +27,56 @@ export interface KeyboardPayload {
   key?: string
 }
 
+/**
+ * The new value emitted by a value-producing control — a switch, checkbox,
+ * radio group, slider, combobox, segmented control. `value` is intentionally
+ * agnostic (`boolean | number | string | …`); each component narrows it for its
+ * own widget. `preventDefault`/`defaultPrevented` mirror the pointer/keyboard
+ * convention so a value change can be vetoed where the substrate supports it.
+ */
+export interface ChangePayload<Value = unknown> {
+  value?: Value
+  defaultPrevented?: boolean
+  /** See PointerPayload.preventDefault. */
+  preventDefault?: () => void
+}
+
+/**
+ * Mousewheel / trackpad scroll deltas (sliders, scrollable surfaces). Web-only
+ * in practice — RN has no wheel input, so the handler is dropped there.
+ * `deltaUnit` is a NEUTRAL enum rather than the DOM `WheelEvent.deltaMode`
+ * magic numbers (0/1/2): the payload stays substrate-agnostic.
+ */
+export interface WheelPayload {
+  deltaX?: number
+  deltaY?: number
+  deltaZ?: number
+  /** Unit the deltas are expressed in. */
+  deltaUnit?: 'pixel' | 'line' | 'page'
+  defaultPrevented?: boolean
+  /** See PointerPayload.preventDefault — suppresses the substrate's default scroll. */
+  preventDefault?: () => void
+}
+
+/**
+ * A neutral scroll-position + geometry snapshot for scroll-container widgets
+ * (listbox, combobox popup, menu, tree, grid) doing active-descendant tracking,
+ * scroll-into-view, snap, or virtualized loading. Field names are
+ * renderer-neutral — NOT the DOM `scrollTop`/`scrollWidth`/`clientWidth` names.
+ * Each target's `normalize` CONSTRUCTS this shape from its native scroll event
+ * (DOM reads `currentTarget.scroll*`; RN reads `nativeEvent.contentOffset` /
+ * `contentSize` / `layoutMeasurement`) rather than forwarding the raw handler.
+ * Read-only — no `preventDefault`.
+ */
+export interface ScrollPayload {
+  offsetX?: number
+  offsetY?: number
+  contentWidth?: number
+  contentHeight?: number
+  viewportWidth?: number
+  viewportHeight?: number
+}
+
 // -----------------------------------------------------------------------------
 // Event bindings — handlers bound to user input
 // -----------------------------------------------------------------------------
@@ -47,6 +97,32 @@ export interface EventBindings {
 
   onKeyDown?: (event?: KeyboardPayload) => void
   onKeyUp?: (event?: KeyboardPayload) => void
+
+  /**
+   * "the control's value changed" — switch/checkbox/radio/slider/combobox.
+   * The renderer-neutral counterpart of the DOM `onChange`/`onInput` and RN
+   * `onValueChange`. The new value rides on the payload.
+   */
+  onValueChange?: <Value = unknown>(event?: ChangePayload<Value>) => void
+
+  /**
+   * Secondary / alternate activation — right-click on web, long-press on touch.
+   * (Context menus, rich editors.)
+   */
+  onContextMenu?: (event?: PointerPayload) => void
+
+  /** Double activation — e.g. table-cell edit, word select. Web-forward; RN has
+   * no built-in multi-tap, so it's dropped there. */
+  onDoublePress?: (event?: PointerPayload) => void
+
+  /** Mousewheel / trackpad deltas (sliders, scrollable lists). Web-only. */
+  onWheel?: (event?: WheelPayload) => void
+
+  /** Scroll-position change on a scroll container — active-descendant tracking,
+   * scroll-into-view, virtualization. */
+  onScroll?: (event?: ScrollPayload) => void
+  /** Scroll deceleration complete — lazy-load / snap. */
+  onScrollEnd?: (event?: ScrollPayload) => void
 }
 
 // -----------------------------------------------------------------------------
@@ -88,4 +164,80 @@ export interface AttrBindings {
 
   /** ARIA role on web; equivalent semantic tag on other substrates. */
   role?: string
+
+  // --- labeling -------------------------------------------------------------
+
+  /** A direct string label, when there's no visible/`labelledBy` text. Primary
+   * screen-reader exposure (web `aria-label`, RN `accessibilityLabel`). */
+  label?: string
+
+  // --- widget state ---------------------------------------------------------
+
+  /** Checkbox / radio / toggle tristate. `'mixed'` is an indeterminate group. */
+  checked?: boolean | 'mixed'
+  /** Toggle-button pressed state (tristate). Web-forward. */
+  pressed?: boolean | 'mixed'
+  /** Marks the current item within a set — the current page/step/etc. */
+  current?: 'page' | 'step' | 'location' | 'date' | 'time' | boolean
+  /** The element is being updated and not yet interactive. */
+  busy?: boolean
+  /** Validity of a user-entered value. */
+  invalid?: boolean | 'grammar' | 'spelling'
+  /** User input is required before submission. */
+  required?: boolean
+  /** The value is not editable but is otherwise operable. */
+  readOnly?: boolean
+
+  // --- relationships --------------------------------------------------------
+
+  /** The id of the descendant a composite widget (menu/listbox/combobox/grid)
+   * treats as virtually focused while DOM focus stays on the container. */
+  activeDescendant?: string
+  /** The id of the element describing this one's validation error. Paired with
+   * `invalid` to be announced. */
+  errorMessage?: string
+  /** The ids of elements this one owns when the DOM hierarchy can't express it. */
+  owns?: string
+
+  // --- value / range (sliders, spinbuttons, progress) -----------------------
+
+  valueMin?: number
+  valueMax?: number
+  valueNow?: number
+  /** A human-readable form of `valueNow` ("70%", "Medium"). */
+  valueText?: string
+
+  // --- structure / orientation ----------------------------------------------
+
+  orientation?: 'horizontal' | 'vertical'
+  /** Sort direction of a sortable column header. */
+  sort?: 'ascending' | 'descending' | 'none' | 'other'
+  /** A combobox/textbox's autocomplete behavior. */
+  autoComplete?: 'none' | 'inline' | 'list' | 'both'
+  /** A textbox accepts multiple lines. */
+  multiline?: boolean
+  /** More than one item may be selected at once. */
+  multiSelectable?: boolean
+  /** Hierarchical level (tree item, heading, nested group). 1-based. */
+  level?: number
+  /** 1-based position of this item within its set. */
+  posInSet?: number
+  /** Total size of the set this item belongs to (for virtualized lists). */
+  setSize?: number
+
+  // --- grid / table ----------------------------------------------------------
+
+  colCount?: number
+  colIndex?: number
+  colSpan?: number
+  rowCount?: number
+  rowIndex?: number
+  rowSpan?: number
+
+  // --- live region -----------------------------------------------------------
+
+  /** How assertively a live region announces updates. */
+  live?: 'off' | 'polite' | 'assertive'
+  /** Announce the whole region (true) or just the changed node (false). */
+  atomic?: boolean
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -63,4 +63,12 @@ export { createStore } from './store'
 export type { Store, Listener, SetStateAction } from './store'
 
 // Bindings vocabulary (agnostic event + attr) connect() speaks.
-export type { AttrBindings, EventBindings, KeyboardPayload, PointerPayload } from './bindings'
+export type {
+  AttrBindings,
+  ChangePayload,
+  EventBindings,
+  KeyboardPayload,
+  PointerPayload,
+  ScrollPayload,
+  WheelPayload,
+} from './bindings'

--- a/packages/core/tests/bindings.test.ts
+++ b/packages/core/tests/bindings.test.ts
@@ -8,7 +8,15 @@
  * reachable and structurally what connect() will speak.
  */
 import { describe, expect, it } from 'vitest'
-import type { AttrBindings, EventBindings, KeyboardPayload, PointerPayload } from '../src'
+import type {
+  AttrBindings,
+  ChangePayload,
+  EventBindings,
+  KeyboardPayload,
+  PointerPayload,
+  ScrollPayload,
+  WheelPayload,
+} from '../src'
 
 describe('bindings vocabulary', () => {
   it('EventBindings carries the agnostic handler names with payloads', () => {
@@ -48,5 +56,68 @@ describe('bindings vocabulary', () => {
     onPress?.({ preventDefault: () => (prevented = true) })
     expect(prevented).toBe(true)
     expect(() => onPress?.()).not.toThrow() // payload is optional
+  })
+
+  it('carries the value-change + interaction handlers (the expanded surface)', () => {
+    const fired: string[] = []
+    const ev: EventBindings = {
+      onValueChange: (e?: ChangePayload) => fired.push(`change:${String(e?.value)}`),
+      onContextMenu: () => fired.push('context'),
+      onDoublePress: () => fired.push('double'),
+      onWheel: (e?: WheelPayload) => fired.push(`wheel:${e?.deltaY ?? 0}`),
+      onScroll: (e?: ScrollPayload) => fired.push(`scroll:${e?.offsetY ?? 0}`),
+      onScrollEnd: () => fired.push('scrollEnd'),
+    }
+    ev.onValueChange?.({ value: true })
+    ev.onWheel?.({ deltaY: 10, deltaUnit: 'pixel' })
+    ev.onScroll?.({ offsetY: 200 })
+    expect(fired).toEqual(['change:true', 'wheel:10', 'scroll:200'])
+  })
+
+  it('ChangePayload narrows its value to the widget type', () => {
+    const sliderChange: EventBindings['onValueChange'] = e => {
+      const n: number | undefined = (e as ChangePayload<number> | undefined)?.value
+      return void n
+    }
+    expect(() => sliderChange?.({ value: 0.5 })).not.toThrow()
+  })
+
+  it('carries the full attribute vocabulary (state, range, structure, live)', () => {
+    const attrs: AttrBindings = {
+      checked: 'mixed',
+      pressed: true,
+      current: 'page',
+      busy: true,
+      invalid: 'spelling',
+      required: true,
+      readOnly: false,
+      label: 'Volume',
+      activeDescendant: 'opt-3',
+      errorMessage: 'err-1',
+      owns: 'listbox-1',
+      valueMin: 0,
+      valueMax: 100,
+      valueNow: 70,
+      valueText: '70%',
+      orientation: 'horizontal',
+      sort: 'ascending',
+      autoComplete: 'list',
+      multiline: true,
+      multiSelectable: false,
+      level: 2,
+      posInSet: 3,
+      setSize: 10,
+      colCount: 5,
+      colIndex: 2,
+      colSpan: 1,
+      rowCount: 20,
+      rowIndex: 4,
+      rowSpan: 1,
+      live: 'polite',
+      atomic: true,
+    }
+    expect(attrs.checked).toBe('mixed')
+    expect(attrs.valueNow).toBe(70)
+    expect(attrs.live).toBe('polite')
   })
 })

--- a/packages/native/src/normalize.ts
+++ b/packages/native/src/normalize.ts
@@ -7,18 +7,32 @@
  * Differences from the React DOM normalizer worth flagging:
  *
  * - `onPress` keeps the same name (RN's Pressable.onPress).
- * - There's NO hover. `onPointerMove`/`onPointerEnter`/`onPointerLeave`
- *   are dropped silently — the consuming view is expected to use a
- *   long-press gesture for tooltip-like activation. Components that
+ * - `onPointerDown`/`onPointerUp` map to RN's `onPressIn`/`onPressOut`.
+ * - There's NO hover. `onPointerMove`/`onPointerEnter`/`onPointerLeave`/
+ *   `onPointerCancel` are dropped silently — the consuming view is expected to
+ *   use a long-press gesture for tooltip-like activation. Components that
  *   need hover-like activation on RN should rely on focus or long-press.
  * - `onFocus` / `onBlur` map to RN's TextInput-style focus events but
- *   only fire for focusable components. The tooltip view doesn't lean
- *   on these on RN.
+ *   only fire for focusable components.
+ * - `onValueChange` maps to RN's shared value-change slot (`onValueChange` —
+ *   Switch/Picker/Slider); `onContextMenu` maps to `onLongPress`;
+ *   `onScroll`/`onScrollEnd` map to `onScroll`/`onMomentumScrollEnd` (scroll
+ *   containers only). `onDoublePress` and `onWheel` have no RN analog → dropped.
  * - `describedBy` becomes `accessibilityLabelledBy` on Android; iOS
  *   doesn't have a direct equivalent (best to merge the description
  *   into accessibilityHint manually in the view).
- * - `expanded`, `selected`, `disabled` become entries in
- *   `accessibilityState`.
+ * - `expanded`, `selected`, `disabled`, `hidden`, plus `checked` and `busy`
+ *   become entries in `accessibilityState` (the only slots RN actually has).
+ * - `valueMin`/`valueMax`/`valueNow`/`valueText` fold into the nested
+ *   `accessibilityValue` object (`{ min, max, now, text }`).
+ * - `label` → `accessibilityLabel`; `live` → `accessibilityLiveRegion`
+ *   (`'off'` becomes RN's `'none'`).
+ * - `controls`, `hasPopup`, `modal` are DOM-ARIA-only and are dropped — RN
+ *   overlays/modals are their own components, not element attributes. So are the
+ *   ARIA attrs with no RN slot (`pressed`, `current`, `invalid`, `required`,
+ *   `readOnly`, `activeDescendant`, `errorMessage`, `owns`, `orientation`,
+ *   `sort`, `autoComplete`, `multiline`, `multiSelectable`, `level`, `posInSet`,
+ *   `setSize`, the grid `col*`/`row*` set, `atomic`).
  * - `role` maps to RN's `accessibilityRole`.
  */
 
@@ -28,9 +42,16 @@ const HANDLER_MAP: Record<string, string> = {
   onPointerUp: 'onPressOut',
   onFocus: 'onFocus',
   onBlur: 'onBlur',
+  // value-change shares RN's onValueChange (Switch/Picker/Slider); context =
+  // long-press; scroll/scroll-end attach to scroll-container components.
+  onValueChange: 'onValueChange',
+  onContextMenu: 'onLongPress',
+  onScroll: 'onScroll',
+  onScrollEnd: 'onMomentumScrollEnd',
 }
 
 // Handlers that have no RN analog. We strip them rather than crash.
+// (`onWheel` — no wheel input; `onDoublePress` — RN has no built-in multi-tap.)
 const HANDLER_DROP = new Set([
   'onPointerEnter',
   'onPointerLeave',
@@ -38,6 +59,8 @@ const HANDLER_DROP = new Set([
   'onPointerCancel',
   'onKeyDown',
   'onKeyUp',
+  'onDoublePress',
+  'onWheel',
 ])
 
 const ATTR_MAP: Record<string, string> = {
@@ -45,15 +68,91 @@ const ATTR_MAP: Record<string, string> = {
   labelledBy: 'accessibilityLabelledBy',
   role: 'accessibilityRole',
   id: 'nativeID',
+  label: 'accessibilityLabel',
+  // NOTE: `live` → accessibilityLiveRegion needs a value transform ('off' →
+  // 'none'), so it's handled inline in normalize(), not through this map.
 }
 
 // Attrs with no clean RN analog — stripped rather than passed through as
-// invalid props. (`controls`/`hasPopup` are DOM ARIA-only; RN menus use their
-// own overlay semantics.)
-const ATTR_DROP = new Set(['controls', 'hasPopup'])
+// invalid props. `controls`/`hasPopup`/`modal` are DOM ARIA-only (RN menus and
+// modals use their own overlay/Modal-component semantics); the rest are ARIA
+// attrs RN has no accessibility slot for — components convey them another way
+// (an error label, editable=false on TextInput, the native focus hierarchy, …).
+const ATTR_DROP = new Set([
+  'controls',
+  'hasPopup',
+  'modal',
+  'pressed',
+  'current',
+  'invalid',
+  'required',
+  'readOnly',
+  'activeDescendant',
+  'errorMessage',
+  'owns',
+  'orientation',
+  'sort',
+  'autoComplete',
+  'multiline',
+  'multiSelectable',
+  'level',
+  'posInSet',
+  'setSize',
+  'colCount',
+  'colIndex',
+  'colSpan',
+  'rowCount',
+  'rowIndex',
+  'rowSpan',
+  'atomic',
+])
 
-// Attrs that fold into accessibilityState.
-const A11Y_STATE_KEYS = new Set(['disabled', 'expanded', 'selected', 'hidden'])
+// Attrs that fold into accessibilityState (RN's slots are exactly these).
+const A11Y_STATE_KEYS = new Set(['disabled', 'expanded', 'selected', 'hidden', 'checked', 'busy'])
+
+// Attrs that fold into the nested accessibilityValue object — logical key → RN
+// sub-key. RN's AccessibilityValue is `{ min, max, now, text }`.
+const A11Y_VALUE_KEYS: Record<string, string> = {
+  valueMin: 'min',
+  valueMax: 'max',
+  valueNow: 'now',
+  valueText: 'text',
+}
+
+// Like the DOM normalizer, some handlers can't just be renamed: RN delivers a
+// different SHAPE than the agnostic payload the component reads. onValueChange
+// gives a BARE value (Switch/Picker/Slider call `onValueChange(value)`);
+// onScroll/onMomentumScrollEnd give `{ nativeEvent: { contentOffset,
+// contentSize, layoutMeasurement } }`. We wrap those so the component still
+// receives ChangePayload / ScrollPayload. (onPress/onPressIn/onPressOut/
+// onLongPress/onFocus/onBlur pass through unwrapped — PointerPayload's optional
+// fields tolerate RN's gesture-responder event.)
+type RNScrollEvent = {
+  nativeEvent?: {
+    contentOffset?: { x?: number; y?: number }
+    contentSize?: { width?: number; height?: number }
+    layoutMeasurement?: { width?: number; height?: number }
+  }
+}
+
+const PAYLOAD_ADAPTERS: Record<string, (arg: unknown) => unknown> = {
+  // RN hands the new value directly.
+  onValueChange: value => ({ value }),
+  onScroll: scrollPayload,
+  onScrollEnd: scrollPayload,
+}
+
+function scrollPayload(e: unknown): unknown {
+  const n = (e as RNScrollEvent)?.nativeEvent ?? {}
+  return {
+    offsetX: n.contentOffset?.x,
+    offsetY: n.contentOffset?.y,
+    contentWidth: n.contentSize?.width,
+    contentHeight: n.contentSize?.height,
+    viewportWidth: n.layoutMeasurement?.width,
+    viewportHeight: n.layoutMeasurement?.height,
+  }
+}
 
 export type Bindings = Record<string, unknown>
 
@@ -61,6 +160,8 @@ export function normalize(logical: Bindings): Record<string, unknown> {
   const out: Record<string, unknown> = {}
   const a11yState: Record<string, unknown> = {}
   let hasA11yState = false
+  const a11yValue: Record<string, unknown> = {}
+  let hasA11yValue = false
 
   for (const [key, value] of Object.entries(logical)) {
     if (value === undefined) continue
@@ -70,7 +171,10 @@ export function normalize(logical: Bindings): Record<string, unknown> {
 
     const handler = HANDLER_MAP[key]
     if (handler) {
-      out[handler] = value
+      const adapt = PAYLOAD_ADAPTERS[key]
+      // Wrap when RN's argument shape differs from the agnostic payload; else
+      // the handler shape already matches, so pass it through.
+      out[handler] = adapt ? (arg: unknown) => (value as (p: unknown) => void)(adapt(arg)) : value
       continue
     }
 
@@ -80,8 +184,24 @@ export function normalize(logical: Bindings): Record<string, unknown> {
       continue
     }
 
+    const valueKey = A11Y_VALUE_KEYS[key]
+    if (valueKey) {
+      a11yValue[valueKey] = value
+      hasA11yValue = true
+      continue
+    }
+
     if (key === 'focusable') {
+      // RN's `focusable` controls hardware-keyboard/D-pad focus; a focusable
+      // element must also be `accessible` to be reachable by the screen reader.
       out.focusable = !!value
+      if (value) out.accessible = true
+      continue
+    }
+
+    if (key === 'live') {
+      // RN's accessibilityLiveRegion uses 'none' where ARIA uses 'off'.
+      out.accessibilityLiveRegion = value === 'off' ? 'none' : value
       continue
     }
 
@@ -96,6 +216,9 @@ export function normalize(logical: Bindings): Record<string, unknown> {
 
   if (hasA11yState) {
     out.accessibilityState = a11yState
+  }
+  if (hasA11yValue) {
+    out.accessibilityValue = a11yValue
   }
 
   return out

--- a/packages/native/tests/normalize.test.ts
+++ b/packages/native/tests/normalize.test.ts
@@ -126,3 +126,172 @@ describe('native normalize — combined surface (tooltip content shape)', () => 
     })
   })
 })
+
+describe('native normalize — DOM-ARIA-only attrs are dropped', () => {
+  it('drops controls / hasPopup / modal (no RN element-attr analog)', () => {
+    const out = normalize({ controls: 'menu:1:content', hasPopup: 'menu', modal: true })
+    expect(out).toEqual({})
+  })
+
+  it('does not leak modal as an invalid RN prop', () => {
+    expect('modal' in normalize({ modal: true })).toBe(false)
+  })
+
+  it('drops the ARIA attrs RN has no slot for', () => {
+    const out = normalize({
+      pressed: true,
+      current: 'page',
+      invalid: true,
+      required: true,
+      readOnly: true,
+      activeDescendant: 'opt-3',
+      errorMessage: 'e1',
+      owns: 'lb1',
+      orientation: 'horizontal',
+      sort: 'ascending',
+      autoComplete: 'list',
+      multiline: true,
+      multiSelectable: true,
+      level: 2,
+      posInSet: 3,
+      setSize: 10,
+      colCount: 5,
+      colIndex: 2,
+      colSpan: 1,
+      rowCount: 20,
+      rowIndex: 4,
+      rowSpan: 1,
+      atomic: true,
+    })
+    expect(out).toEqual({})
+  })
+})
+
+describe('native normalize — focusable pairs with accessible', () => {
+  it('pairs a focusable element with accessible:true (reachable by SR)', () => {
+    expect(normalize({ focusable: true })).toEqual({ focusable: true, accessible: true })
+  })
+
+  it('does not force accessible when not focusable', () => {
+    const out = normalize({ focusable: false })
+    expect(out.focusable).toBe(false)
+    expect('accessible' in out).toBe(false)
+  })
+})
+
+describe('native normalize — expanded handler surface', () => {
+  it('maps onValueChange / onContextMenu / scroll to their RN slots', () => {
+    const out = normalize({
+      onValueChange: vi.fn(),
+      onContextMenu: vi.fn(),
+      onScroll: vi.fn(),
+      onScrollEnd: vi.fn(),
+    })
+    expect(Object.keys(out).sort()).toEqual(
+      ['onValueChange', 'onLongPress', 'onScroll', 'onMomentumScrollEnd'].sort(),
+    )
+  })
+
+  it('passes onContextMenu through to onLongPress unwrapped', () => {
+    const onContextMenu = vi.fn()
+    expect(normalize({ onContextMenu }).onLongPress).toBe(onContextMenu)
+  })
+
+  it('onValueChange receives a ChangePayload built from RN’s bare value', () => {
+    const onValueChange = vi.fn()
+    const out = normalize({ onValueChange })
+    ;(out.onValueChange as (v: unknown) => void)(true)
+    expect(onValueChange).toHaveBeenCalledWith({ value: true })
+  })
+
+  it('onScroll / onScrollEnd receive a neutral ScrollPayload from nativeEvent', () => {
+    const onScroll = vi.fn()
+    const out = normalize({ onScroll })
+    ;(out.onScroll as (e: unknown) => void)({
+      nativeEvent: {
+        contentOffset: { x: 5, y: 50 },
+        contentSize: { width: 800, height: 1200 },
+        layoutMeasurement: { width: 400, height: 600 },
+      },
+    })
+    expect(onScroll).toHaveBeenCalledWith({
+      offsetX: 5,
+      offsetY: 50,
+      contentWidth: 800,
+      contentHeight: 1200,
+      viewportWidth: 400,
+      viewportHeight: 600,
+    })
+  })
+
+  it('drops onDoublePress and onWheel (no RN analog)', () => {
+    expect(normalize({ onDoublePress: vi.fn(), onWheel: vi.fn() })).toEqual({})
+  })
+})
+
+describe('native normalize — accessibilityState additions', () => {
+  it('folds checked and busy into accessibilityState (with existing keys)', () => {
+    expect(normalize({ checked: 'mixed', busy: true, disabled: false })).toEqual({
+      accessibilityState: { checked: 'mixed', busy: true, disabled: false },
+    })
+  })
+})
+
+describe('native normalize — accessibilityValue fold', () => {
+  it('folds valueMin/Max/Now/Text into a nested accessibilityValue object', () => {
+    expect(normalize({ valueMin: 0, valueMax: 100, valueNow: 70, valueText: '70%' })).toEqual({
+      accessibilityValue: { min: 0, max: 100, now: 70, text: '70%' },
+    })
+  })
+
+  it('omits accessibilityValue entirely when no value-* keys are present', () => {
+    expect('accessibilityValue' in normalize({ role: 'slider' })).toBe(false)
+  })
+})
+
+describe('native normalize — label + live region', () => {
+  it('maps label to accessibilityLabel', () => {
+    expect(normalize({ label: 'Volume' })).toEqual({ accessibilityLabel: 'Volume' })
+  })
+
+  it('maps live to accessibilityLiveRegion, translating off → none', () => {
+    expect(normalize({ live: 'off' })).toEqual({ accessibilityLiveRegion: 'none' })
+    expect(normalize({ live: 'polite' })).toEqual({ accessibilityLiveRegion: 'polite' })
+    expect(normalize({ live: 'assertive' })).toEqual({ accessibilityLiveRegion: 'assertive' })
+  })
+
+  it('drops atomic (no RN slot) but keeps live', () => {
+    expect(normalize({ live: 'polite', atomic: true })).toEqual({
+      accessibilityLiveRegion: 'polite',
+    })
+  })
+})
+
+describe('native normalize — realistic slider shape', () => {
+  it('translates a slider binding set across state/value/label/handler', () => {
+    const onValueChange = vi.fn()
+    const out = normalize({
+      role: 'slider',
+      label: 'Volume',
+      orientation: 'horizontal', // dropped (no RN slot)
+      valueMin: 0,
+      valueMax: 100,
+      valueNow: 40,
+      valueText: '40%',
+      disabled: false,
+      focusable: true,
+      onValueChange,
+    })
+    expect(out).toMatchObject({
+      accessibilityRole: 'slider',
+      accessibilityLabel: 'Volume',
+      accessibilityValue: { min: 0, max: 100, now: 40, text: '40%' },
+      accessibilityState: { disabled: false },
+      focusable: true,
+      accessible: true,
+    })
+    expect('orientation' in out).toBe(false) // dropped, no RN slot
+    ;(out.onValueChange as (v: unknown) => void)(60)
+    expect(onValueChange).toHaveBeenCalledWith({ value: 60 })
+  })
+})

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -155,7 +155,11 @@ The selector reads from the machine directly, so it auto-subscribes to exactly
 the fields it touches (the same auto-tracking the core's
 [`select`](../core/README.md#subscriptions--observing-changes) gives you); the
 component re-renders only when the selected value changes — `Object.is` by
-default, or pass a custom `isEqual` for object selections:
+default. **A selector that returns a fresh object/array each call MUST pass a
+custom `isEqual`** — otherwise every evaluation yields a new identity that
+`Object.is` deems "changed", and `useSyncExternalStore` re-renders in a loop.
+Prefer selecting primitives; reach for `isEqual` when you genuinely need a
+composite:
 
 ```ts
 const pos = useSelector(
@@ -191,17 +195,31 @@ const domProps = normalize(api.triggerProps) // { onClick, aria-describedby, rol
 
 The mapping:
 
-| Agnostic binding                                              | DOM/ARIA prop                                                       |
-| ------------------------------------------------------------- | ------------------------------------------------------------------- |
-| `onPress`                                                     | `onClick`                                                           |
-| `onPointerEnter/Leave/Move/Down`, `onFocus/Blur`, `onKeyDown` | same name (already DOM-shaped)                                      |
-| `describedBy` / `labelledBy`                                  | `aria-describedby` / `aria-labelledby`                              |
-| `expanded` / `selected` / `disabled` / `hidden`               | `aria-expanded` / `aria-selected` / `aria-disabled` / `aria-hidden` |
-| `focusable`                                                   | `tabIndex` (`true → 0`, `false → -1`)                               |
-| `role` / `id`                                                 | `role` / `id`                                                       |
+| Agnostic binding                                                                                | DOM/ARIA prop                                                                      |
+| ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `onPress`                                                                                       | `onClick`                                                                          |
+| `onValueChange`                                                                                 | `onChange` (wrapped → `ChangePayload`)                                             |
+| `onContextMenu` / `onDoublePress`                                                               | `onContextMenu` / `onDoubleClick`                                                  |
+| `onWheel` / `onScroll` / `onScrollEnd`                                                          | same name (wrapped → `WheelPayload` / `ScrollPayload`)                             |
+| `onPointerEnter/Leave/Move/Down/Up/Cancel`, `onFocus/Blur`, `onKeyDown/Up`                      | same name (already DOM-shaped)                                                     |
+| `describedBy` / `labelledBy` / `controls` / `label`                                             | `aria-describedby` / `aria-labelledby` / `aria-controls` / `aria-label`            |
+| `expanded` / `selected` / `disabled` / `hidden` / `modal`                                       | `aria-expanded` / `aria-selected` / `aria-disabled` / `aria-hidden` / `aria-modal` |
+| `checked` / `pressed` / `current` / `busy` / `invalid` / `required` / `readOnly`                | matching `aria-*` (value untransformed)                                            |
+| `valueMin/Max/Now/Text`                                                                         | `aria-valuemin` / `-valuemax` / `-valuenow` / `-valuetext`                         |
+| `orientation` / `sort` / `autoComplete` / `level` / `posInSet` / `setSize` / grid `col*`/`row*` | the matching `aria-*` attr                                                         |
+| `activeDescendant` / `errorMessage` / `owns` / `hasPopup`                                       | `aria-activedescendant` / `-errormessage` / `-owns` / `-haspopup`                  |
+| `live` / `atomic`                                                                               | `aria-live` / `aria-atomic`                                                        |
+| `focusable`                                                                                     | `tabIndex` (`true → 0`, `false → -1`)                                              |
+| `role` / `id`                                                                                   | `role` / `id`                                                                      |
 
-`undefined` values are dropped, and any key not in the map passes through
-unchanged — so a binding the renderer already understands needs no entry.
+The logical names are renderer-neutral by design — `onPress` not `onClick`,
+`onValueChange` not `onChange`, `checked` not `aria-checked` — so the same
+`connect` output drives DOM, React Native, or canvas, each through its own
+`normalize`. A few handlers whose agnostic payload differs from the raw event
+(`onValueChange`/`onWheel`/`onScroll`/`onScrollEnd`) are wrapped so the consumer
+receives the agnostic payload, not the DOM event. `undefined` values are
+dropped, and any key not in the map passes through unchanged — so a binding the
+renderer already understands needs no entry.
 
 ---
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -32,8 +32,12 @@
     "build": "tsdown"
   },
   "devDependencies": {
+    "@testing-library/react": "^16.1.0",
     "@types/react": "^19.2.15",
-    "react": "^19.2.6"
+    "@types/react-dom": "^19.2.3",
+    "jsdom": "^29.1.1",
+    "react": "^19.2.6",
+    "react-dom": "^19.2.6"
   },
   "peerDependencies": {
     "@chimba-ui/shared-state-machine": "workspace:^",

--- a/packages/react/src/normalize.ts
+++ b/packages/react/src/normalize.ts
@@ -11,9 +11,74 @@ const HANDLER_MAP: Record<string, string> = {
   onPointerLeave: 'onPointerLeave',
   onPointerMove: 'onPointerMove',
   onPointerDown: 'onPointerDown',
+  onPointerUp: 'onPointerUp',
+  onPointerCancel: 'onPointerCancel',
   onFocus: 'onFocus',
   onBlur: 'onBlur',
   onKeyDown: 'onKeyDown',
+  onKeyUp: 'onKeyUp',
+  // value-change + secondary/double activation + scroll/wheel. onValueChange/
+  // onWheel/onScroll/onScrollEnd additionally have their argument translated
+  // from the raw DOM event into the agnostic payload (see PAYLOAD_ADAPTERS).
+  onValueChange: 'onChange',
+  onContextMenu: 'onContextMenu',
+  onDoublePress: 'onDoubleClick',
+  onWheel: 'onWheel',
+  onScroll: 'onScroll',
+  onScrollEnd: 'onScrollEnd',
+}
+
+// Some handlers can't just be renamed: the agnostic payload the component reads
+// (`ChangePayload`/`WheelPayload`/`ScrollPayload`) is a different SHAPE from the
+// raw React synthetic event. For those, normalize wraps the handler so the
+// component receives the agnostic payload — built here from the DOM event —
+// rather than the DOM event itself. (onPress/pointer/keyboard handlers already
+// receive a shape that overlaps PointerPayload/KeyboardPayload, so they pass
+// through unwrapped, exactly as onPress always has.)
+
+// DOM WheelEvent.deltaMode (0/1/2) → the neutral WheelPayload unit.
+const WHEEL_UNIT = ['pixel', 'line', 'page'] as const
+
+type AnyEvent = {
+  target?: { value?: unknown; checked?: unknown; type?: string }
+  currentTarget?: Record<string, number>
+  deltaX?: number
+  deltaY?: number
+  deltaZ?: number
+  deltaMode?: number
+  defaultPrevented?: boolean
+  preventDefault?: () => void
+}
+
+const PAYLOAD_ADAPTERS: Record<string, (e: AnyEvent) => unknown> = {
+  onValueChange: e => {
+    const t = e?.target
+    // checkbox/radio carry the boolean on `.checked`; everything else on `.value`.
+    const value = t && (t.type === 'checkbox' || t.type === 'radio') ? t.checked : t?.value
+    return { value, defaultPrevented: e?.defaultPrevented, preventDefault: e?.preventDefault }
+  },
+  onWheel: e => ({
+    deltaX: e?.deltaX,
+    deltaY: e?.deltaY,
+    deltaZ: e?.deltaZ,
+    deltaUnit: WHEEL_UNIT[e?.deltaMode ?? 0] ?? 'pixel',
+    defaultPrevented: e?.defaultPrevented,
+    preventDefault: e?.preventDefault,
+  }),
+  onScroll: scrollPayload,
+  onScrollEnd: scrollPayload,
+}
+
+function scrollPayload(e: AnyEvent): unknown {
+  const el = e?.currentTarget ?? {}
+  return {
+    offsetX: el.scrollLeft,
+    offsetY: el.scrollTop,
+    contentWidth: el.scrollWidth,
+    contentHeight: el.scrollHeight,
+    viewportWidth: el.clientWidth,
+    viewportHeight: el.clientHeight,
+  }
 }
 
 const ATTR_MAP: Record<string, string> = {
@@ -29,6 +94,46 @@ const ATTR_MAP: Record<string, string> = {
   focusable: 'tabIndex', // value transformed below
   role: 'role',
   id: 'id',
+
+  // labeling
+  label: 'aria-label',
+  // widget state (values pass through untransformed — booleans, the 'mixed'
+  // tristate, and the aria-current / aria-invalid enums all serialize as-is)
+  checked: 'aria-checked',
+  pressed: 'aria-pressed',
+  current: 'aria-current',
+  busy: 'aria-busy',
+  invalid: 'aria-invalid',
+  required: 'aria-required',
+  readOnly: 'aria-readonly',
+  // relationships
+  activeDescendant: 'aria-activedescendant',
+  errorMessage: 'aria-errormessage',
+  owns: 'aria-owns',
+  // value / range
+  valueMin: 'aria-valuemin',
+  valueMax: 'aria-valuemax',
+  valueNow: 'aria-valuenow',
+  valueText: 'aria-valuetext',
+  // structure / orientation
+  orientation: 'aria-orientation',
+  sort: 'aria-sort',
+  autoComplete: 'aria-autocomplete',
+  multiline: 'aria-multiline',
+  multiSelectable: 'aria-multiselectable',
+  level: 'aria-level',
+  posInSet: 'aria-posinset',
+  setSize: 'aria-setsize',
+  // grid / table
+  colCount: 'aria-colcount',
+  colIndex: 'aria-colindex',
+  colSpan: 'aria-colspan',
+  rowCount: 'aria-rowcount',
+  rowIndex: 'aria-rowindex',
+  rowSpan: 'aria-rowspan',
+  // live region
+  live: 'aria-live',
+  atomic: 'aria-atomic',
 }
 
 export type Bindings = Record<string, unknown>
@@ -40,7 +145,10 @@ export function normalize(logical: Bindings): Record<string, unknown> {
 
     const handler = HANDLER_MAP[key]
     if (handler) {
-      out[handler] = value
+      const adapt = PAYLOAD_ADAPTERS[key]
+      // Wrap when the agnostic payload differs from the raw DOM event; else the
+      // handler shape already matches (PointerPayload/KeyboardPayload), pass it.
+      out[handler] = adapt ? (e: AnyEvent) => (value as (p: unknown) => void)(adapt(e)) : value
       continue
     }
 

--- a/packages/react/src/use-selector.ts
+++ b/packages/react/src/use-selector.ts
@@ -28,6 +28,14 @@ import type { EqualityFn, Machine } from '@chimba-ui/state-machine'
  * Selection, so a per-render-fresh `selector` (e.g. one closing over a `value`
  * prop) always evaluates its latest form WITHOUT re-creating the Selection or
  * re-subscribing every render. Only `m` changing rebuilds the subscription.
+ *
+ * getSnapshot returns a value cached in a ref, refreshed only when the selected
+ * value actually changes (Object.is, or the caller's `isEqual`). That stable
+ * identity is REQUIRED: useSyncExternalStore re-renders whenever successive
+ * getSnapshot results differ by Object.is, so an object selection that returned
+ * a fresh `{...}` each call would re-render forever. The cache makes object
+ * selections safe (and `isEqual` the way to dedup them); primitives are
+ * unaffected.
  */
 export function useSelector<
   State extends string,
@@ -49,21 +57,44 @@ export function useSelector<
   const selectorRef = useRef(selector)
   selectorRef.current = selector
 
+  // Keep the LATEST isEqual in a ref too: getSnapshot (below) consults it to
+  // decide whether a freshly-evaluated value is "the same" as the cached one.
+  // It can change identity per render (an inline arrow), so reading it through a
+  // ref keeps getSnapshot stable without re-subscribing.
+  const isEqualRef = useRef(isEqual)
+  isEqualRef.current = isEqual
+
   // One Selection over a stable wrapper that reads the current selector. Built
   // once per machine; re-evaluated on every machine notify and value-deduped
   // (coarse bus + value compare, not field-level dependency tracking).
   const selectorMemo = useMemo(() => machine.select(() => selectorRef.current()), [machine])
 
+  // Cache the last value getSnapshot returned. useSyncExternalStore compares
+  // successive getSnapshot results by Object.is and re-renders whenever they
+  // differ — so getSnapshot MUST stay referentially stable while the selected
+  // value is unchanged. A raw `selectorRef.current()` breaks that for object
+  // selections: a fresh `{...}` every call is never Object.is-equal to the last,
+  // so React would re-render forever. We hold the last value in a ref and only
+  // replace it when the newly-evaluated value actually changed — Object.is by
+  // default, or the caller's `isEqual` for object selections. Primitives are
+  // unaffected (Object.is on equal primitives is true, so the cache is a no-op).
+  const cache = useRef<{ value: T } | null>(null)
+  const getSnapshot = (): T => {
+    const next = selectorRef.current()
+    const eq = isEqualRef.current ?? Object.is
+    if (cache.current && eq(cache.current.value, next)) return cache.current.value
+    cache.current = { value: next }
+    return next
+  }
+
   return useSyncExternalStore(
+    // The Selection's value-dedup still gates the bus → React notification (so a
+    // change to an UNRELATED field doesn't even wake this leaf). getSnapshot's
+    // cache is the second line of defense: it keeps the returned identity stable
+    // so React itself doesn't re-render on an equal value. The two together give
+    // both "don't wake on unrelated changes" and "don't loop on object identity".
     onStoreChange => selectorMemo.subscribe(() => onStoreChange(), isEqual),
-    // getSnapshot evaluates the selector DIRECTLY rather than reading
-    // selectorMemo.value. `.value` lazily builds a preact computed on first
-    // read, and React calls getSnapshot during every leaf's mount render — so
-    // routing through `.value` would allocate a computed node per leaf at mount.
-    // The snapshot read doesn't need tracking (only `subscribe` does), so a
-    // plain eval is correct and skips that per-leaf allocation. The Selection's
-    // reactive node is still built lazily if anyone reads `.value` elsewhere.
-    () => selectorRef.current(),
-    () => selectorRef.current(),
+    getSnapshot,
+    getSnapshot,
   )
 }

--- a/packages/react/tests/normalize.test.ts
+++ b/packages/react/tests/normalize.test.ts
@@ -1,0 +1,295 @@
+/**
+ * React DOM bindings translator — pure-logic tests (no DOM runtime needed).
+ *
+ * `normalize` maps the core's substrate-agnostic logical surface
+ * (`@chimba-ui/state-machine`'s `EventBindings` + `AttrBindings`) to real
+ * DOM/ARIA props. These tests pin the FULL vocabulary so every logical binding
+ * has an explicit, asserted DOM target — nothing relies on accidental
+ * pass-through.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import { normalize } from '@chimba-ui/react-state-machine'
+
+describe('react normalize — handlers', () => {
+  it('maps onPress to onClick (the DOM activation event)', () => {
+    const onPress = vi.fn()
+    expect(normalize({ onPress })).toEqual({ onClick: onPress })
+  })
+
+  it('maps the full pointer family to DOM pointer events', () => {
+    const handlers = {
+      onPointerEnter: vi.fn(),
+      onPointerLeave: vi.fn(),
+      onPointerMove: vi.fn(),
+      onPointerDown: vi.fn(),
+      onPointerUp: vi.fn(),
+      onPointerCancel: vi.fn(),
+    }
+    expect(normalize(handlers)).toEqual(handlers)
+  })
+
+  it('passes onFocus / onBlur through', () => {
+    const onFocus = vi.fn()
+    const onBlur = vi.fn()
+    expect(normalize({ onFocus, onBlur })).toEqual({ onFocus, onBlur })
+  })
+
+  it('maps both keyboard handlers (onKeyDown / onKeyUp)', () => {
+    const onKeyDown = vi.fn()
+    const onKeyUp = vi.fn()
+    expect(normalize({ onKeyDown, onKeyUp })).toEqual({ onKeyDown, onKeyUp })
+  })
+})
+
+describe('react normalize — attributes', () => {
+  it('maps the ARIA reference attrs (describedBy / labelledBy / controls)', () => {
+    expect(normalize({ describedBy: 'd', labelledBy: 'l', controls: 'c' })).toEqual({
+      'aria-describedby': 'd',
+      'aria-labelledby': 'l',
+      'aria-controls': 'c',
+    })
+  })
+
+  it('maps hasPopup to aria-haspopup (string or boolean)', () => {
+    expect(normalize({ hasPopup: 'menu' })).toEqual({ 'aria-haspopup': 'menu' })
+    expect(normalize({ hasPopup: true })).toEqual({ 'aria-haspopup': true })
+  })
+
+  it('maps the boolean state attrs to their aria-* equivalents', () => {
+    expect(
+      normalize({ expanded: true, selected: false, disabled: true, hidden: false, modal: true }),
+    ).toEqual({
+      'aria-expanded': true,
+      'aria-selected': false,
+      'aria-disabled': true,
+      'aria-hidden': false,
+      'aria-modal': true,
+    })
+  })
+
+  it('maps focusable to tabIndex (true → 0, false → -1)', () => {
+    expect(normalize({ focusable: true })).toEqual({ tabIndex: 0 })
+    expect(normalize({ focusable: false })).toEqual({ tabIndex: -1 })
+  })
+
+  it('maps role and id straight through (same name)', () => {
+    expect(normalize({ role: 'tooltip', id: 't:1' })).toEqual({ role: 'tooltip', id: 't:1' })
+  })
+
+  it('passes unknown attrs through unchanged (e.g. data-state)', () => {
+    expect(normalize({ 'data-state': 'open' })).toEqual({ 'data-state': 'open' })
+  })
+
+  it('skips undefined values', () => {
+    expect(normalize({ role: undefined, id: 'x' })).toEqual({ id: 'x' })
+  })
+})
+
+describe('react normalize — combined surface (trigger shape)', () => {
+  it('translates a realistic trigger binding set', () => {
+    const onPress = vi.fn()
+    const out = normalize({
+      id: 'menu:1:trigger',
+      role: 'button',
+      controls: 'menu:1:content',
+      hasPopup: 'menu',
+      expanded: true,
+      focusable: true,
+      onPress,
+      onKeyDown: vi.fn(),
+      'data-state': 'open',
+    })
+    expect(out).toMatchObject({
+      id: 'menu:1:trigger',
+      role: 'button',
+      'aria-controls': 'menu:1:content',
+      'aria-haspopup': 'menu',
+      'aria-expanded': true,
+      tabIndex: 0,
+      onClick: onPress,
+      'data-state': 'open',
+    })
+    expect(typeof out.onKeyDown).toBe('function')
+  })
+})
+
+describe('react normalize — expanded handler surface', () => {
+  it('maps each value-change / interaction handler to its DOM event prop', () => {
+    const out = normalize({
+      onValueChange: vi.fn(),
+      onContextMenu: vi.fn(),
+      onDoublePress: vi.fn(),
+      onWheel: vi.fn(),
+      onScroll: vi.fn(),
+      onScrollEnd: vi.fn(),
+    })
+    expect(Object.keys(out).sort()).toEqual(
+      ['onChange', 'onContextMenu', 'onDoubleClick', 'onScroll', 'onScrollEnd', 'onWheel'].sort(),
+    )
+  })
+
+  it('passes onContextMenu / onDoublePress through unwrapped (same payload shape)', () => {
+    const onContextMenu = vi.fn()
+    const onDoublePress = vi.fn()
+    const out = normalize({ onContextMenu, onDoublePress })
+    expect(out.onContextMenu).toBe(onContextMenu)
+    expect(out.onDoubleClick).toBe(onDoublePress)
+  })
+
+  it('onValueChange receives a ChangePayload built from the DOM event', () => {
+    const onValueChange = vi.fn()
+    const out = normalize({ onValueChange })
+    ;(out.onChange as (e: unknown) => void)({ target: { value: 'hi', type: 'text' } })
+    expect(onValueChange).toHaveBeenCalledWith({
+      value: 'hi',
+      defaultPrevented: undefined,
+      preventDefault: undefined,
+    })
+    ;(out.onChange as (e: unknown) => void)({ target: { checked: true, type: 'checkbox' } })
+    expect(onValueChange).toHaveBeenLastCalledWith(expect.objectContaining({ value: true }))
+  })
+
+  it('onWheel receives a WheelPayload with a neutral deltaUnit (deltaMode → enum)', () => {
+    const onWheel = vi.fn()
+    const out = normalize({ onWheel })
+    ;(out.onWheel as (e: unknown) => void)({ deltaX: 1, deltaY: 2, deltaZ: 0, deltaMode: 1 })
+    expect(onWheel).toHaveBeenCalledWith(
+      expect.objectContaining({ deltaX: 1, deltaY: 2, deltaZ: 0, deltaUnit: 'line' }),
+    )
+  })
+
+  it('onScroll / onScrollEnd receive a neutral ScrollPayload from currentTarget geometry', () => {
+    const onScroll = vi.fn()
+    const out = normalize({ onScroll })
+    ;(out.onScroll as (e: unknown) => void)({
+      currentTarget: {
+        scrollLeft: 5,
+        scrollTop: 50,
+        scrollWidth: 800,
+        scrollHeight: 1200,
+        clientWidth: 400,
+        clientHeight: 600,
+      },
+    })
+    expect(onScroll).toHaveBeenCalledWith({
+      offsetX: 5,
+      offsetY: 50,
+      contentWidth: 800,
+      contentHeight: 1200,
+      viewportWidth: 400,
+      viewportHeight: 600,
+    })
+  })
+})
+
+describe('react normalize — expanded attribute surface', () => {
+  it('maps widget-state attrs to aria-*, preserving tristate/enum values', () => {
+    expect(
+      normalize({
+        checked: 'mixed',
+        pressed: true,
+        current: 'page',
+        busy: true,
+        invalid: 'spelling',
+        required: true,
+        readOnly: false,
+      }),
+    ).toEqual({
+      'aria-checked': 'mixed',
+      'aria-pressed': true,
+      'aria-current': 'page',
+      'aria-busy': true,
+      'aria-invalid': 'spelling',
+      'aria-required': true,
+      'aria-readonly': false,
+    })
+  })
+
+  it('maps labeling + relationship attrs', () => {
+    expect(
+      normalize({ label: 'Volume', activeDescendant: 'opt-3', errorMessage: 'e1', owns: 'lb1' }),
+    ).toEqual({
+      'aria-label': 'Volume',
+      'aria-activedescendant': 'opt-3',
+      'aria-errormessage': 'e1',
+      'aria-owns': 'lb1',
+    })
+  })
+
+  it('maps value/range attrs (slider shape)', () => {
+    expect(normalize({ valueMin: 0, valueMax: 100, valueNow: 70, valueText: '70%' })).toEqual({
+      'aria-valuemin': 0,
+      'aria-valuemax': 100,
+      'aria-valuenow': 70,
+      'aria-valuetext': '70%',
+    })
+  })
+
+  it('maps structure + grid attrs', () => {
+    expect(
+      normalize({
+        orientation: 'horizontal',
+        sort: 'ascending',
+        autoComplete: 'list',
+        multiline: true,
+        multiSelectable: false,
+        level: 2,
+        posInSet: 3,
+        setSize: 10,
+        colCount: 5,
+        colIndex: 2,
+        colSpan: 1,
+        rowCount: 20,
+        rowIndex: 4,
+        rowSpan: 1,
+      }),
+    ).toEqual({
+      'aria-orientation': 'horizontal',
+      'aria-sort': 'ascending',
+      'aria-autocomplete': 'list',
+      'aria-multiline': true,
+      'aria-multiselectable': false,
+      'aria-level': 2,
+      'aria-posinset': 3,
+      'aria-setsize': 10,
+      'aria-colcount': 5,
+      'aria-colindex': 2,
+      'aria-colspan': 1,
+      'aria-rowcount': 20,
+      'aria-rowindex': 4,
+      'aria-rowspan': 1,
+    })
+  })
+
+  it('maps live-region attrs (off passes through as aria-live="off")', () => {
+    expect(normalize({ live: 'off', atomic: true })).toEqual({
+      'aria-live': 'off',
+      'aria-atomic': true,
+    })
+  })
+
+  it('translates a realistic slider binding set', () => {
+    const onValueChange = vi.fn()
+    const out = normalize({
+      role: 'slider',
+      orientation: 'horizontal',
+      valueMin: 0,
+      valueMax: 100,
+      valueNow: 40,
+      valueText: '40%',
+      focusable: true,
+      onValueChange,
+    })
+    expect(out).toMatchObject({
+      role: 'slider',
+      'aria-orientation': 'horizontal',
+      'aria-valuemin': 0,
+      'aria-valuemax': 100,
+      'aria-valuenow': 40,
+      'aria-valuetext': '40%',
+      tabIndex: 0,
+    })
+    ;(out.onChange as (e: unknown) => void)({ target: { value: '50', type: 'range' } })
+    expect(onValueChange).toHaveBeenCalledWith(expect.objectContaining({ value: '50' }))
+  })
+})

--- a/packages/react/tests/use-machine.test.tsx
+++ b/packages/react/tests/use-machine.test.tsx
@@ -1,0 +1,233 @@
+// @vitest-environment jsdom
+/**
+ * `useMachine` — the React bridge hook. These tests pin the behavioral contract
+ * the README documents: build ONCE, run the machine lifecycle (start on mount /
+ * stop on unmount), keep consumer props fresh via setProps (value-deduped, never
+ * during render), run the connector's reactions across the machine lifecycle,
+ * run each ComponentEffect as its own dep-keyed useEffect, and drive React off
+ * the connector's stable snapshot — returning `{ api, machine }`.
+ */
+import { StrictMode } from 'react'
+import { act, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  act as write,
+  machine,
+  makeReaction,
+  type Connect,
+  type TransitionConfig,
+} from '@chimba-ui/state-machine'
+import { type ComponentEffects, useMachine } from '@chimba-ui/react-state-machine'
+
+type ToggleState = 'closed' | 'open'
+interface ToggleCtx {
+  count: number
+}
+type ToggleEvent = { type: 'toggle' }
+
+interface ToggleProps {
+  label?: string
+  onOpenChange?: (open: boolean) => void
+}
+
+const createConfig =
+  (): ((props: ToggleProps) => TransitionConfig<ToggleState, ToggleCtx, ToggleEvent>) => () => ({
+    initial: 'closed',
+    context: { count: 0 },
+    states: {
+      closed: {
+        on: { toggle: { target: 'open', actions: write($ => ({ count: $.context.count + 1 })) } },
+      },
+      open: { on: { toggle: { target: 'closed' } } },
+    },
+  })
+
+type ToggleApi = {
+  open: boolean
+  label: string | undefined
+  count: number
+  toggle: () => void
+}
+
+const connect: Connect<ToggleState, ToggleCtx, ToggleEvent, ToggleProps, ToggleApi> = ({
+  state,
+  context,
+  props,
+  send,
+}) => ({
+  open: state === 'open',
+  label: props.label,
+  count: context.count,
+  toggle: () => send({ type: 'toggle' }),
+})
+
+const reaction = makeReaction<ToggleState, ToggleCtx, ToggleEvent, ToggleProps>()
+connect.reactions = [
+  reaction(
+    m => m.state === 'open',
+    (open, props) => props.onOpenChange?.(open),
+  ),
+]
+
+type ToggleMachine = ReturnType<typeof machine<ToggleState, ToggleCtx, ToggleEvent>>
+const noEffects: ComponentEffects<ToggleMachine, ToggleProps> = []
+
+afterEach(() => vi.clearAllMocks())
+
+function harness(
+  props: ToggleProps,
+  effects: ComponentEffects<ToggleMachine, ToggleProps> = noEffects,
+) {
+  const sink: { api?: ToggleApi; machine?: ToggleMachine; renders: number } = { renders: 0 }
+  function Comp(p: ToggleProps) {
+    const { api, machine: m } = useMachine(createConfig(), connect, effects, p)
+    sink.api = api
+    sink.machine = m
+    sink.renders++
+    return <div data-testid='label'>{api.label ?? '∅'}</div>
+  }
+  return { sink, Comp, props }
+}
+
+describe('useMachine — lifecycle', () => {
+  it('returns { api, machine }: api is the connect() output, machine is the running service', () => {
+    const { sink, Comp, props } = harness({ label: 'hi' })
+    render(<Comp {...props} />)
+    expect(sink.api).toMatchObject({ open: false, label: 'hi', count: 0 })
+    expect(typeof sink.api!.toggle).toBe('function')
+    expect(typeof sink.machine!.send).toBe('function')
+  })
+
+  it('starts the machine on mount and stops it on unmount', () => {
+    const { sink, Comp, props } = harness({})
+    const { unmount } = render(<Comp {...props} />)
+    act(() => sink.api!.toggle())
+    expect(sink.api!.open).toBe(true)
+    expect(() => unmount()).not.toThrow()
+  })
+
+  it('re-renders the component when the snapshot changes (useSyncExternalStore)', () => {
+    const { sink, Comp, props } = harness({})
+    render(<Comp {...props} />)
+    const before = sink.renders
+    act(() => sink.api!.toggle())
+    expect(sink.renders).toBeGreaterThan(before)
+    expect(sink.api!.open).toBe(true)
+    expect(sink.api!.count).toBe(1)
+  })
+})
+
+describe('useMachine — build once', () => {
+  it('builds the machine ONCE: state survives prop changes (no rebuild)', () => {
+    const { sink, Comp } = harness({ label: 'a' })
+    const { rerender } = render(<Comp label='a' />)
+    act(() => sink.api!.toggle()) // → open, count 1
+    expect(sink.api!.open).toBe(true)
+
+    rerender(<Comp label='b' />) // prop change must NOT rebuild/reset state
+    expect(sink.api!.open).toBe(true)
+    expect(sink.api!.count).toBe(1)
+    expect(sink.api!.label).toBe('b') // but the new prop IS reflected
+  })
+})
+
+describe('useMachine — props freshness via setProps', () => {
+  it('flows later prop changes into the snapshot (setProps, not rebuild)', () => {
+    const { sink, Comp } = harness({ label: 'first' })
+    const { rerender } = render(<Comp label='first' />)
+    expect(sink.api!.label).toBe('first')
+    rerender(<Comp label='second' />)
+    expect(sink.api!.label).toBe('second')
+  })
+
+  it('value-dedups: an equal props object re-render does not churn the snapshot', () => {
+    const { sink, Comp } = harness({ label: 'x' })
+    const { rerender } = render(<Comp label='x' />)
+    const snap1 = sink.api
+    rerender(<Comp label='x' />) // fresh props object, equal values
+    expect(sink.api).toBe(snap1) // stable identity → no recompute
+  })
+})
+
+describe('useMachine — reactions follow the machine lifecycle', () => {
+  it('fires the connect reaction (onOpenChange) when state flips while mounted', () => {
+    const onOpenChange = vi.fn()
+    const { sink, Comp } = harness({ onOpenChange })
+    render(<Comp onOpenChange={onOpenChange} />)
+    expect(onOpenChange).not.toHaveBeenCalled() // not on subscribe
+    act(() => sink.api!.toggle())
+    expect(onOpenChange).toHaveBeenCalledWith(true)
+    act(() => sink.api!.toggle())
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+})
+
+describe('useMachine — component effects', () => {
+  it('runs each ComponentEffect as its own effect (setup on mount, cleanup on unmount)', () => {
+    const setup = vi.fn()
+    const cleanup = vi.fn()
+    const effects: ComponentEffects<ToggleMachine, ToggleProps> = [[() => (setup(), cleanup), []]]
+    const { Comp } = harness({}, effects)
+    const { unmount } = render(<Comp />)
+    expect(setup).toHaveBeenCalledOnce()
+    expect(cleanup).not.toHaveBeenCalled()
+    unmount()
+    expect(cleanup).toHaveBeenCalledOnce()
+  })
+
+  it('re-runs an effect ONLY when one of its named prop deps changes', () => {
+    const fn = vi.fn(() => () => {})
+    const effects: ComponentEffects<ToggleMachine, ToggleProps> = [[fn, ['label']]]
+    const { Comp } = harness({ label: 'a' }, effects)
+    const { rerender } = render(<Comp label='a' />)
+    expect(fn).toHaveBeenCalledTimes(1)
+
+    rerender(<Comp label='a' />) // dep unchanged → no re-run
+    expect(fn).toHaveBeenCalledTimes(1)
+
+    rerender(<Comp label='b' />) // dep changed → re-run
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  it('does NOT re-run an effect when a NON-dep prop changes', () => {
+    const fn = vi.fn(() => () => {})
+    const effects: ComponentEffects<ToggleMachine, ToggleProps> = [[fn, ['label']]]
+    const { Comp } = harness({ label: 'a' }, effects)
+    const { rerender } = render(<Comp label='a' onOpenChange={() => {}} />)
+    expect(fn).toHaveBeenCalledTimes(1)
+    rerender(<Comp label='a' onOpenChange={() => {}} />) // new fn identity, label same
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('receives (machine, props) and can read live machine state', () => {
+    let seenOpen: boolean | undefined
+    const effects: ComponentEffects<ToggleMachine, ToggleProps> = [
+      [
+        m => {
+          seenOpen = m.matches('open')
+        },
+        [],
+      ],
+    ]
+    const { Comp } = harness({}, effects)
+    render(<Comp />)
+    expect(seenOpen).toBe(false)
+  })
+})
+
+describe('useMachine — StrictMode (mount → unmount → mount)', () => {
+  it('survives the StrictMode double-mount without throwing and stays functional', () => {
+    const onOpenChange = vi.fn()
+    const { sink, Comp } = harness({ onOpenChange })
+    expect(() =>
+      render(
+        <StrictMode>
+          <Comp onOpenChange={onOpenChange} />
+        </StrictMode>,
+      ),
+    ).not.toThrow()
+    act(() => sink.api!.toggle())
+    expect(sink.api!.open).toBe(true)
+    expect(onOpenChange).toHaveBeenLastCalledWith(true)
+  })
+})

--- a/packages/react/tests/use-selector.test.tsx
+++ b/packages/react/tests/use-selector.test.tsx
@@ -1,0 +1,197 @@
+// @vitest-environment jsdom
+/**
+ * `useSelector` — fine-grained leaf subscription. These tests pin the README
+ * contract: the selector reads the machine directly, the component re-renders
+ * ONLY when the selected value changes (value-deduped, `Object.is` by default,
+ * custom `isEqual` for object selections), a fresh per-render selector closure
+ * still evaluates its latest form without re-subscribing, and a change to one
+ * leaf's slice wakes only that leaf (the O(readers) property).
+ */
+import { act, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { act as write, machine, type TransitionConfig } from '@chimba-ui/state-machine'
+import { useSelector } from '@chimba-ui/react-state-machine'
+
+type S = 'idle'
+interface Ctx {
+  a: number
+  b: number
+}
+type Ev = { type: 'incA' } | { type: 'incB' } | { type: 'noop' }
+
+const config: TransitionConfig<S, Ctx, Ev> = {
+  initial: 'idle',
+  context: { a: 0, b: 0 },
+  states: {
+    idle: {
+      on: {
+        // context writes go through setContext (via `act`) so the bus notifies —
+        // a raw in-place `context.a++` mutates the value but never wakes subscribers.
+        incA: write($ => ({ a: $.context.a + 1 })),
+        incB: write($ => ({ b: $.context.b + 1 })),
+        noop: () => {},
+      },
+    },
+  },
+}
+
+function makeMachine() {
+  const m = machine(config)
+  m.start()
+  return m
+}
+
+afterEach(() => vi.clearAllMocks())
+
+describe('useSelector — value-deduped re-renders', () => {
+  it('reads the machine directly and reflects the selected value', () => {
+    const m = makeMachine()
+    let seen: number | undefined
+    function Comp() {
+      seen = useSelector(m, () => m.context.a)
+      return null
+    }
+    render(<Comp />)
+    expect(seen).toBe(0)
+    act(() => m.send({ type: 'incA' }))
+    expect(seen).toBe(1)
+  })
+
+  it('re-renders ONLY when the selected slice changes (not on every machine change)', () => {
+    const m = makeMachine()
+    const renders = vi.fn()
+    function Comp() {
+      const a = useSelector(m, () => m.context.a)
+      renders()
+      return <span>{a}</span>
+    }
+    render(<Comp />)
+    expect(renders).toHaveBeenCalledTimes(1)
+
+    act(() => m.send({ type: 'incB' })) // selects `a`, `b` changed → no re-render
+    expect(renders).toHaveBeenCalledTimes(1)
+
+    act(() => m.send({ type: 'noop' })) // nothing changed → no re-render
+    expect(renders).toHaveBeenCalledTimes(1)
+
+    act(() => m.send({ type: 'incA' })) // `a` changed → re-render
+    expect(renders).toHaveBeenCalledTimes(2)
+  })
+
+  it('defaults to Object.is equality (a re-derived equal value does not re-render)', () => {
+    const m = makeMachine()
+    const renders = vi.fn()
+    function Comp() {
+      useSelector(m, () => m.context.a > 0) // boolean: flips only at 0→1
+      renders()
+      return null
+    }
+    render(<Comp />)
+    expect(renders).toHaveBeenCalledTimes(1)
+    act(() => m.send({ type: 'incA' })) // false → true (re-render)
+    expect(renders).toHaveBeenCalledTimes(2)
+    act(() => m.send({ type: 'incA' })) // true → true (no re-render)
+    expect(renders).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('useSelector — custom isEqual for object selections', () => {
+  it('uses the provided isEqual to dedup an object selection', () => {
+    const m = makeMachine()
+    const renders = vi.fn()
+    function Comp() {
+      useSelector(
+        m,
+        () => ({ a: m.context.a }),
+        (x, y) => x.a === y.a,
+      )
+      renders()
+      return null
+    }
+    render(<Comp />)
+    expect(renders).toHaveBeenCalledTimes(1)
+
+    act(() => m.send({ type: 'incB' })) // selected {a} unchanged → no re-render
+    expect(renders).toHaveBeenCalledTimes(1)
+
+    act(() => m.send({ type: 'incA' })) // {a} changed → re-render
+    expect(renders).toHaveBeenCalledTimes(2)
+  })
+
+  it('a custom isEqual makes getSnapshot referentially stable across re-evaluations (no loop)', () => {
+    // Regression guard: an object selection WITH isEqual must hold a stable
+    // identity between real changes. Without the getSnapshot cache, useSync
+    // ExternalStore re-evaluates, sees a fresh `{...}` each call, and loops with
+    // "Maximum update depth exceeded". This asserts the cache holds.
+    const m = makeMachine()
+    let last: { a: number } | undefined
+    function Comp() {
+      last = useSelector(
+        m,
+        () => ({ a: m.context.a }),
+        (x, y) => x.a === y.a,
+      )
+      return null
+    }
+    expect(() => render(<Comp />)).not.toThrow()
+    const firstIdentity = last
+    act(() => m.send({ type: 'incB' })) // unrelated change: same object identity
+    expect(last).toBe(firstIdentity)
+    act(() => m.send({ type: 'incA' })) // real change: new value
+    expect(last).not.toBe(firstIdentity)
+    expect(last).toEqual({ a: 1 })
+  })
+})
+
+describe('useSelector — fresh per-render selector closure', () => {
+  it('evaluates the LATEST selector closure (closing over a changing prop) without re-subscribing', () => {
+    const m = makeMachine()
+    let seen: boolean | undefined
+    function Comp({ target }: { target: number }) {
+      seen = useSelector(m, () => m.context.a === target)
+      return null
+    }
+    const { rerender } = render(<Comp target={0} />)
+    expect(seen).toBe(true) // a=0 === target 0
+
+    rerender(<Comp target={1} />) // new closure; a still 0 → 0 === 1 is false
+    expect(seen).toBe(false)
+
+    act(() => m.send({ type: 'incA' })) // a → 1; latest closure compares to target 1
+    expect(seen).toBe(true)
+  })
+})
+
+describe('useSelector — O(readers): a slice change wakes only its reader', () => {
+  it('re-renders only the leaf whose selected slice changed', () => {
+    const m = makeMachine()
+    const aRenders = vi.fn()
+    const bRenders = vi.fn()
+    function LeafA() {
+      useSelector(m, () => m.context.a)
+      aRenders()
+      return null
+    }
+    function LeafB() {
+      useSelector(m, () => m.context.b)
+      bRenders()
+      return null
+    }
+    render(
+      <>
+        <LeafA />
+        <LeafB />
+      </>,
+    )
+    expect(aRenders).toHaveBeenCalledTimes(1)
+    expect(bRenders).toHaveBeenCalledTimes(1)
+
+    act(() => m.send({ type: 'incA' })) // only LeafA's slice changed
+    expect(aRenders).toHaveBeenCalledTimes(2)
+    expect(bRenders).toHaveBeenCalledTimes(1)
+
+    act(() => m.send({ type: 'incB' })) // only LeafB's slice changed
+    expect(aRenders).toHaveBeenCalledTimes(2)
+    expect(bRenders).toHaveBeenCalledTimes(2)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,12 +151,24 @@ importers:
         specifier: workspace:^
         version: link:../core
     devDependencies:
+      '@testing-library/react':
+        specifier: ^16.1.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@types/react':
         specifier: ^19.2.15
         version: 19.2.15
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.15)
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       react:
         specifier: ^19.2.6
         version: 19.2.6
+      react-dom:
+        specifier: ^19.2.6
+        version: 19.2.6(react@19.2.6)
 
   packages/shared/utils: {}
 
@@ -1324,8 +1336,30 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -1507,6 +1541,9 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
@@ -1673,6 +1710,10 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
@@ -1688,6 +1729,9 @@ packages:
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dotenv@8.6.0:
     resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
@@ -2168,6 +2212,10 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -2449,6 +2497,10 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -2491,6 +2543,9 @@ packages:
     resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
     peerDependencies:
       react: ^19.2.6
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
@@ -4044,10 +4099,33 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@testing-library/dom': 10.4.1
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.15
+      '@types/react-dom': 19.2.3(@types/react@19.2.15)
+
   '@tybys/wasm-util@0.10.2':
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.3':
     dependencies:
@@ -4230,6 +4308,10 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
   array-union@2.1.0: {}
 
   asap@2.0.6: {}
@@ -4388,6 +4470,8 @@ snapshots:
 
   depd@2.0.0: {}
 
+  dequal@2.0.3: {}
+
   destroy@1.2.0: {}
 
   detect-indent@6.1.0: {}
@@ -4397,6 +4481,8 @@ snapshots:
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
+
+  dom-accessibility-api@0.5.16: {}
 
   dotenv@8.6.0: {}
 
@@ -4872,6 +4958,8 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -5277,6 +5365,12 @@ snapshots:
 
   prettier@2.8.8: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   pretty-format@29.7.0:
     dependencies:
       '@jest/schemas': 29.6.3
@@ -5322,6 +5416,8 @@ snapshots:
     dependencies:
       react: 19.2.6
       scheduler: 0.27.0
+
+  react-is@17.0.2: {}
 
   react-is@18.3.1: {}
 


### PR DESCRIPTION
## What

Expands the substrate-agnostic **bindings vocabulary** (`packages/core/src/bindings.ts`) from ~23 to ~60 logical bindings, and makes both target `normalize()`s translate the whole set correctly — including **payload construction**, not just key renaming.

The vocabulary was designed from React's *real* `DOMAttributes` + `AriaAttributes` surface (88 events / 53 aria attrs enumerated from `@types/react`) and adversarially verified for substrate correctness, so headless components (sliders, comboboxes, switches, listboxes, trees, grids, dialogs, …) have the logical concepts they actually need — while keeping names renderer-neutral (`onValueChange` not `onChange`, `checked` not `aria-checked`).

## Core (`packages/core`)

- **New payloads:** `ChangePayload<V>`, `WheelPayload` (neutral `deltaUnit`, not the DOM `deltaMode` magic numbers), `ScrollPayload` (renderer-neutral field names).
- **New handlers:** `onValueChange`, `onContextMenu`, `onDoublePress`, `onWheel`, `onScroll`, `onScrollEnd`.
- **New attrs:** `label`, `checked`, `pressed`, `current`, `busy`, `invalid`, `required`, `readOnly`, `activeDescendant`, `errorMessage`, `owns`, `valueMin/Max/Now/Text`, `orientation`, `sort`, `autoComplete`, `multiline`, `multiSelectable`, `level`, `posInSet`, `setSize`, grid `col*`/`row*`, `live`, `atomic`.

## React DOM normalizer

- Complete `HANDLER_MAP`/`ATTR_MAP` for the full vocabulary (also fixes the previously-implicit `onPointerUp`/`onPointerCancel`/`onKeyUp`).
- **Payload adapters:** `onValueChange`/`onWheel`/`onScroll`/`onScrollEnd` are wrapped so the consumer receives the agnostic payload built from the DOM event, not the raw synthetic event.

## React Native normalizer

- `onValueChange`→`onValueChange`, `onContextMenu`→`onLongPress`, `onScroll`→`onScroll`, `onScrollEnd`→`onMomentumScrollEnd` (payload-adapted from RN's event/value).
- `checked`/`busy` fold into `accessibilityState`; `valueMin/Max/Now/Text` fold into a new `accessibilityValue` object; `label`→`accessibilityLabel`; `live`→`accessibilityLiveRegion` (`'off'`→`'none'`); `focusable` also sets `accessible`.
- Fixes the **`modal` leak**; drops DOM-ARIA-only / no-RN-slot attrs explicitly instead of passing them through as invalid props.

## `useSelector` bug fix

- Fixes an **infinite-render loop**: `getSnapshot` now caches its result in a ref (`Object.is` / caller `isEqual`), as the README already documented. Object selections with `isEqual` are now stable instead of looping.

## Tests + docs

- Full `normalize` coverage on both substrates (including firing the payload adapters) and the expanded core vocabulary.
- New jsdom hook suites for `useMachine` (12) and `useSelector` (7) — these hooks previously had **zero** test coverage and there was no DOM test environment.
- React README mapping table + the `isEqual` requirement documented.

**283 tests pass; typecheck + lint clean.**

> Note: a follow-up changeset entry is worth adding for the `useSelector` fix (user-facing behavior change) — happy to add one if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)