### PR TITLE
fix(benchmark): stop the instant the last engine falls behind

### DIFF
--- a/benchmark/demo/src/app.tsx
+++ b/benchmark/demo/src/app.tsx
@@ -14,7 +14,6 @@ const RAMP_STEP = 1500
 const RAMP_EVERY_MS = 1200
 const PAINT_EVERY_MS = 100 // throttle canvas paint to ~10fps (off the hot path)
 const OVERFLOW_AT = 3000 // backlog over this = decisively "falling behind"
-const STOP_GRACE_MS = 1000 // after all 3 cross, keep going briefly so the lag is visible
 
 const ENGINE_IDS: PanelId[] = ['chimba', 'xstate', 'zag'] // raw doesn't count
 
@@ -78,7 +77,6 @@ export function App() {
     let lastSample = performance.now()
     let lastPaint = performance.now()
     let frames = 0
-    let allBehindSince = 0 // timestamp when all 3 engines first crossed
     const applied: Record<PanelId, number> = { raw: 0, chimba: 0, xstate: 0, zag: 0 }
     // queued captured at first overflow, per panel (persists across samples)
     const overflowedAt: Record<PanelId, number | null> = {
@@ -145,16 +143,14 @@ export function App() {
         frames = 0
         lastSample = t
 
-        // auto-stop once ALL THREE engines have fallen behind — but give a short
-        // grace so their backlogs grow to a representative size before freezing
+        // auto-stop the instant the LAST engine falls behind — freeze everything
+        // immediately so the "fell behind by N" flags reflect the moment of
+        // divergence and don't keep growing.
         if (ENGINE_IDS.every(id => overflowedAt[id] !== null)) {
-          if (allBehindSince === 0) allBehindSince = t
-          else if (t - allBehindSince >= STOP_GRACE_MS) {
-            runningRef.current = false
-            cancelAnimationFrame(loop.current)
-            setRunning(false)
-            return
-          }
+          runningRef.current = false
+          cancelAnimationFrame(loop.current)
+          setRunning(false)
+          return
         }
       }
 


### PR DESCRIPTION
## What

The live engine-throughput demo (`benchmark/demo`) auto-stops once all three engines (Chimba / XState / Zag) fall behind. Previously it kept running for a 1s `STOP_GRACE_MS` window *after* the last one crossed, during which each panel's **"fell behind by N"** flag kept growing — so the frozen numbers didn't reflect the actual moment of divergence.


https://github.com/user-attachments/assets/ecfb8051-151f-4314-abd6-00d60a1fdb66



## Change

Drop the grace window: the loop now freezes **the instant the last engine's red border appears**. The `fell behind by N` flags are captured at the point of divergence and stop climbing.

- Removed `STOP_GRACE_MS` and the `allBehindSince` bookkeeping.
- `ENGINE_IDS.every(overflowed)` → stop immediately.

## Notes

🎥 Video showing the fix to be added by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)