### PR TITLE
Extract binding vocabulary into @dunky.dev/state-machine-bindings

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,74 +1,37 @@
-// Public surface of the engine, re-exported from the per-concern modules.
-
-// The single public factory + its service type.
 export { machine } from './machine'
-export type { Machine } from './types'
-
-// The synthetic boot event (start()).
 export { MACHINE_INIT } from './constants'
-
-// Config types (annotate a config literal when needed; for authoring, use setup()).
-export type { MachineConfig, TransitionConfig, Transition, Implementations } from './types'
-
-// The authoring entry point. `setup().createMachine(literal)` for a quick config
-// (types inferred, names loose); `setup<Ctx,Ev>().config(registries).createMachine(...)`
-// to check every guard/action/effect/delay name (a typo becomes a compile error).
 export { setup } from './setup'
-
-// Per-state node shape (used when annotating a config's `states`).
-export type { StateNode } from './types'
-// NOTE: state and context have no standalone modules — they're plain fields on
-// the machine instance (getter-free reads, inline-deduped in-place writes); see
-// machine.ts. What IS factored into its own module is the logic with real
-// complexity: computed tracking (./computed) and transition selection
-// (./transitions).
-
-// Guards: combinators + types.
 export { and, or, not } from './guards'
-export type { Guard, GuardArg, GuardParams } from './types'
-
-// Action helpers, used inside an `actions` / `entry` / `exit` list: `act` (terse
-// context-write sugar) + `oneOf` (variadic conditional — first passing branch
-// wins). Structure (`target` / `guard`) stays on the plain transition object.
 export { act, oneOf } from './actions'
-export type { Action, ActionArg, ActionParams, OneOf } from './types'
-
-// Effects + types.
-export type { Effect, EffectArg } from './types'
-
-// Timed transitions.
-export type { Delay } from './types'
-
-// Computed.
-export type { ComputedDef, ComputedDefs } from './types'
-
-// Subscription surface (select / Selection).
-export type { Selection, Select, EqualityFn } from './types'
-
-// Connector boundary (live snapshot) + connect typing.
 export { connector } from './connector'
-export type { Connect, Connector, ConnectSnapshot, Reaction } from './types'
-
-// Reaction authoring helper: infers the selector→callback value link.
 export { makeReaction } from './reaction'
+export { compose, type Composition } from './compose'
+export { createStore, type Store, type Listener, type SetStateAction } from './store'
 
-// Composition — run several independent machines as one unit (orthogonal
-// regions): bundled lifecycle + sync (cross-region rules) + combine (one
-// deduped Selection across members).
-export { compose } from './compose'
-export type { Composition } from './compose'
-
-// A tiny store (plain value + listeners) for cross-instance singletons (wrap in a facade).
-export { createStore } from './store'
-export type { Store, Listener, SetStateAction } from './store'
-
-// Bindings vocabulary (agnostic event + attr) connect() speaks.
 export type {
-  AttrBindings,
-  ChangePayload,
-  EventBindings,
-  KeyboardPayload,
-  PointerPayload,
-  ScrollPayload,
-  WheelPayload,
-} from './bindings'
+  Machine,
+  MachineConfig,
+  TransitionConfig,
+  Transition,
+  Implementations,
+  StateNode,
+  Guard,
+  GuardArg,
+  GuardParams,
+  Action,
+  ActionArg,
+  ActionParams,
+  OneOf,
+  Effect,
+  EffectArg,
+  Delay,
+  ComputedDef,
+  ComputedDefs,
+  Selection,
+  Select,
+  EqualityFn,
+  Connect,
+  Connector,
+  ConnectSnapshot,
+  Reaction,
+} from './types'

--- a/packages/shared/bindings/package.json
+++ b/packages/shared/bindings/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@dunky.dev/state-machine-bindings",
+  "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dunky-dev/state-machine.git",
+    "directory": "packages/shared/bindings"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "sideEffects": false,
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "publishConfig": {
+    "main": "./dist/index.js",
+    "module": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsdown"
+  }
+}

--- a/packages/shared/bindings/src/index.ts
+++ b/packages/shared/bindings/src/index.ts
@@ -1,3 +1,18 @@
+// =============================================================================
+// @dunky.dev/state-machine-bindings
+//
+// The neutral binding vocabulary a `connect()` speaks — substrate-agnostic event
+// handlers (`onPress`, `onValueChange`) and attributes (`role`, `expanded`,
+// `describedBy`). Zero runtime, zero dependencies: pure types.
+//
+// This is the contract between behavior and platform. A `connect()` produces
+// these bindings without knowing whether it runs on web, React Native, canvas,
+// or a headless test; each renderer's `normalize()` is the ONLY code that turns
+// them into platform props (web `aria-expanded`/`onClick`, RN
+// `accessibilityState`/`onPress`). Splitting the vocabulary into its own package
+// lets a renderer depend on the contract WITHOUT pulling in the engine.
+// =============================================================================
+
 // -----------------------------------------------------------------------------
 // Event payloads
 // -----------------------------------------------------------------------------

--- a/packages/shared/bindings/tests/bindings.test.ts
+++ b/packages/shared/bindings/tests/bindings.test.ts
@@ -1,5 +1,5 @@
 /**
- * Bindings vocabulary (re-exported from the engine surface).
+ * Bindings vocabulary — the standalone, engine-free contract.
  *
  * Pins the agnostic event + attr vocabulary a component's connect() emits,
  * BEFORE any target translation. These are types; the test asserts the shape

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,6 +170,8 @@ importers:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
 
+  packages/shared/bindings: {}
+
   packages/shared/utils: {}
 
   website:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,8 @@
       "@dunky.dev/state-machine": ["./packages/core/src"],
       "@dunky.dev/react-state-machine": ["./packages/react/src"],
       "@dunky.dev/native-state-machine": ["./packages/native/src"],
-      "@dunky.dev/shared-state-machine": ["./packages/shared/utils/src"]
+      "@dunky.dev/shared-state-machine": ["./packages/shared/utils/src"],
+      "@dunky.dev/state-machine-bindings": ["./packages/shared/bindings/src"]
     },
     "types": ["@types/node", "vitest/globals"]
   },

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -9,7 +9,13 @@ export default defineConfig({
   // src/tests dirs, and `include: 'auto'` walks node_modules + grabs the non-published
   // benchmark/website packages — so for this layout an explicit list is the clean
   // choice. Keep in sync with the publish set in .changeset/config.json.
-  workspace: ['packages/core', 'packages/react', 'packages/native', 'packages/shared/utils'],
+  workspace: [
+    'packages/core',
+    'packages/react',
+    'packages/native',
+    'packages/shared/utils',
+    'packages/shared/bindings',
+  ],
   entry: ['src/index.ts'],
   format: ['esm'],
   // Every package is `"type": "module"`, so a plain `.js` is already ESM — emit


### PR DESCRIPTION
## What

Extracts the agnostic binding vocabulary — the event handlers (`onPress`, `onValueChange`) and attributes (`role`, `expanded`, `describedBy`) that a component's `connect()` speaks — out of the core engine and into its own zero-dependency package, **`@dunky.dev/state-machine-bindings`**.

## Why

The binding vocabulary is the *contract between behavior and platform*. A `connect()` produces these neutral bindings without knowing whether it runs on web, React Native, canvas, or a headless test; each renderer's `normalize()` is the only code that turns them into platform props.

Living inside core, that contract was only reachable *through* the engine. As its own package, a renderer (React, RN, a future Vue/Solid binding) can depend on the **contract** without pulling in the **engine** — which is exactly the structural line that distinguishes Dunky's platform-agnostic model:

- **XState** — core is agnostic but has *no binding layer at all*; you hand-write every `onClick`/`aria-*` per platform.
- **Zag** — `@zag-js/core` imports `@zag-js/dom-query` and emits DOM-shaped props; framework-agnostic but web-coupled.
- **Dunky** — one config + one `connect` speaking this neutral vocabulary; only `normalize` is platform-specific.

## Changes

- **New package** `packages/shared/bindings` (`@dunky.dev/state-machine-bindings`) — pure types, no runtime, `publint`-clean.
- **Core no longer owns or re-exports the vocabulary** — it *produces* bindings, it doesn't *define* them. Removed the (now-dead) dependency.
- Moved the bindings test alongside the package it tests.
- Merged core's per-module exports into one statement per source module, using the inline `type` modifier where runtime + type mix.
- Wired the package into `tsconfig` paths and the `tsdown` workspace list. The changeset `@dunky.dev/*` fixed-group glob picks it up automatically.

## Verification

- `tsc` typecheck: clean
- All 5 packages build; `publint` passes on each
- 283 tests pass (6 in the bindings package's new home)
- Emitted `.d.ts` confirms every public export survived the merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)