### PR TITLE
Fix pacman demo board not resetting after caught

### DIFF
--- a/website/src/demos/pacman.ts
+++ b/website/src/demos/pacman.ts
@@ -311,13 +311,17 @@ export function createBoardMachine(): BoardMachine {
         on: {
           reset: {
             target: 'playing',
+            // Build a FRESH dots Set / cherry on each reset. A static `act({...})`
+            // would bake one Set instance in at construction time; since `eat`
+            // mutates that Set in place (delete), reusing it would replay an
+            // already-eaten board — leaving dots permanently gone after a reset.
             actions: [
-              act({
+              act(() => ({
                 dots: initialDots([PAC_START, GHOST_START]),
                 cherry: { ...CHERRY_START } as Pt | null,
                 score: 0,
                 status: 'playing' as BoardCtx['status'],
-              }),
+              })),
             ],
           },
         },


### PR DESCRIPTION
## Problem

The `reset` transition in the pacman board machine used a static `act({...})`. The patch object — including the `dots` Set built by `initialDots(...)` — was evaluated **once at machine-construction time**, so the same Set instance was reused across every reset.

Because `eat` mutates that Set in place (via `delete`), each reset re-applied the already-mutated board. The result: after the first game, eaten dots stayed gone — resetting from the `caught` state never restored a full board.

## Fix

Wrap the patch in a function — `act(() => ({...}))` — so the patch is evaluated lazily each time the action runs. This builds a **fresh** `dots` Set and `cherry` on every reset.

`act` already supports function-form patches (evaluated at action-run time in `packages/core/src/actions.ts`), so this is the intended API for state that must be reconstructed per transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)