### PR TITLE
fix(website,readme): broken logos and base-relative links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="./website/public/logo%402x.png" alt="Dunky" width="400px" />
+  <img src="./website/public/logo/logo%402x.png" alt="Dunky" width="400px" />
 </p>
 
 # STATE-MACHINE

--- a/sandbox/native/package.json
+++ b/sandbox/native/package.json
@@ -11,9 +11,9 @@
   "dependencies": {
     "@dunky.dev/native-state-machine": "workspace:*",
     "@dunky.dev/react-state-machine": "workspace:*",
-    "@dunky.dev/state-machine-utils": "workspace:*",
     "@dunky.dev/state-machine": "workspace:*",
     "@dunky.dev/state-machine-bindings": "workspace:*",
+    "@dunky.dev/state-machine-utils": "workspace:*",
     "@sandbox/cmdk-core": "workspace:*",
     "expo": "^54.0.0",
     "expo-status-bar": "~3.0.0",

--- a/sandbox/opentui/package.json
+++ b/sandbox/opentui/package.json
@@ -9,9 +9,9 @@
   "dependencies": {
     "@dunky.dev/opentui-state-machine": "workspace:*",
     "@dunky.dev/react-state-machine": "workspace:*",
-    "@dunky.dev/state-machine-utils": "workspace:*",
     "@dunky.dev/state-machine": "workspace:*",
     "@dunky.dev/state-machine-bindings": "workspace:*",
+    "@dunky.dev/state-machine-utils": "workspace:*",
     "@opentui/core": "^0.4.1",
     "@opentui/react": "^0.4.1",
     "@sandbox/cmdk-core": "workspace:*",

--- a/sandbox/react/package.json
+++ b/sandbox/react/package.json
@@ -10,9 +10,9 @@
   },
   "dependencies": {
     "@dunky.dev/react-state-machine": "workspace:*",
-    "@dunky.dev/state-machine-utils": "workspace:*",
     "@dunky.dev/state-machine": "workspace:*",
     "@dunky.dev/state-machine-bindings": "workspace:*",
+    "@dunky.dev/state-machine-utils": "workspace:*",
     "@sandbox/cmdk-core": "workspace:*",
     "react": "^19.2.6",
     "react-dom": "^19.2.6"

--- a/website/src/components/header.astro
+++ b/website/src/components/header.astro
@@ -5,7 +5,9 @@
 // On the homepage the bar is hidden and only slides in after the visitor has
 // scrolled past the hero (~500px). Pass `revealOnScroll` to enable that; every
 // other page keeps the bar pinned and always visible.
-const base = import.meta.env.BASE_URL
+// `trailingSlash: 'never'` strips BASE_URL's trailing slash, so normalize to
+// exactly one slash before the `${base}…` concatenations below resolve.
+const base = import.meta.env.BASE_URL.replace(/\/?$/, '/')
 const repo = 'https://github.com/dunky-dev/state-machine'
 
 interface Props {

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -8,7 +8,11 @@ import pacmanSrc from "../snippets/pacman.code.ts?raw";
 import tradingSrc from "../snippets/trading-panel.code.ts?raw";
 import whiteboardSrc from "../snippets/whiteboard.code.ts?raw";
 
-const base = import.meta.env.BASE_URL;
+// With `trailingSlash: 'never'`, Astro hands us BASE_URL without a trailing
+// slash (e.g. `/state-machine`), so `${base}get-started` would render as
+// `/state-machineget-started`. Normalize to exactly one trailing slash so the
+// `${base}…` concatenations below (links, logo, favicon) all resolve.
+const base = import.meta.env.BASE_URL.replace(/\/?$/, "/");
 const repo = "https://github.com/dunky-dev/state-machine";
 
 // "Share on X", an intent URL (prefilled tweet + link), not a profile link.
@@ -26,7 +30,7 @@ const shareOnX = `https://twitter.com/intent/tweet?text=${encodeURIComponent(sha
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Dunky: a state machine built for performance</title>
-    <link rel="icon" href={`${base}logo-symbol.svg`} type="image/svg+xml" />
+    <link rel="icon" href={`${base}logo/logo-symbol.svg`} type="image/svg+xml" />
     <meta
       name="description"
       content="A state machine built for performance, inspired by XState and Zag. Define a behavior once, render it anywhere."


### PR DESCRIPTION
## Symptoms
- Every logo is broken on the GitHub README and on https://www.dunky.dev/state-machine.
- Internal links 404 — e.g. **Get started** resolved to `https://www.dunky.dev/state-machineget-started` (note the missing `/`).

## Root causes (two unrelated breakages)

**1. Missing trailing slash on `base`**
With `trailingSlash: 'never'` in `astro.config.ts`, Astro hands `import.meta.env.BASE_URL` to templates **without** a trailing slash (`/state-machine`). The homepage and header concatenate `${base}get-started`, `${base}logo/logo.svg`, etc. — which produced `/state-machineget-started`, `/state-machinelogo/logo.svg`, and so on. So every `${base}…` link and asset on the home page and the header 404'd.

Fix: normalize `base` to exactly one trailing slash in `index.astro` and `header.astro`.

**2. Logo assets moved into a `logo/` subdir**
The `website/public/logo` submodule now stores assets under `logo/` (`logo/logo@2x.png`, `logo/logo-symbol.svg`, …). Two references still pointed at the old flat paths:
- Homepage favicon: `${base}logo-symbol.svg` → `${base}logo/logo-symbol.svg`
- README image: `./website/public/logo%402x.png` → `./website/public/logo/logo%402x.png`

## Verification
Rebuilt the site and scanned all 28 built pages — no `/state-machine<letter>` broken concatenations remain. Confirmed:
- `href="/state-machine/get-started"`
- `src="/state-machine/logo/logo.svg"`
- `href="/state-machine/logo/logo-symbol.svg"` (favicon)
- `href="/state-machine/benchmark"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)