### PR TITLE
fix(readme): serve logo from raw URL instead of submodule path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="./website/public/logo/logo%402x.png" alt="Dunky" width="400px" />
+  <img src="https://raw.githubusercontent.com/dunky-dev/logo/main/logo%402x.png" alt="Dunky" width="400px" />
 </p>
 
 # STATE-MACHINE


### PR DESCRIPTION
The README logo was still broken on github.com after #19.

**Why:** the logo lives in the `dunky-dev/logo` submodule, mounted at `website/public/logo`. The previous fix corrected the relative path, but GitHub's README renderer **does not resolve relative image paths into submodules** — so it rendered as a broken image regardless of the path being correct.

**Fix:** point the `<img>` at the logo repo's raw URL (`https://raw.githubusercontent.com/dunky-dev/logo/main/logo@2x.png`), which GitHub serves directly. Verified the URL returns `200 image/png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)