### PR TITLE
chore(ci): rename Publish workflow to Release

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -1,7 +1,7 @@
 name: CI checks
 
 # The full CI suite as parallel jobs. Runs directly on every PR, and is also
-# reused by publish.yml as a gate before releasing (workflow_call).
+# reused by release.yml as a gate before releasing (workflow_call).
 on:
   pull_request:
     branches: ['**']

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Publish
+name: Release
 
 on:
   push:


### PR DESCRIPTION
Renames the release pipeline workflow for clarity:

- `.github/workflows/publish.yml` → `.github/workflows/release.yml`
- internal `name: Publish` → `name: Release`
- updates the stale `publish.yml` reference in `ci-checks.yml`'s comment

No behavioral change — same triggers (`push` to `main`), same jobs, same changesets action. Only the file path and display name change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)