### PR TITLE
chore(website): add Vercel Speed Insights

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,6 +314,9 @@ importers:
       '@vercel/analytics':
         specifier: ^2.0.1
         version: 2.0.1(react@19.2.6)
+      '@vercel/speed-insights':
+        specifier: ^2.0.0
+        version: 2.0.0(react@19.2.6)
     devDependencies:
       '@astrojs/mdx':
         specifier: ^6.0.3
@@ -3025,6 +3028,32 @@ packages:
     peerDependenciesMeta:
       '@remix-run/react':
         optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
+
+  '@vercel/speed-insights@2.0.0':
+    resolution: {integrity: sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==}
+    peerDependencies:
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
       '@sveltejs/kit':
         optional: true
       next:
@@ -9493,6 +9522,10 @@ snapshots:
       wonka: 6.3.6
 
   '@vercel/analytics@2.0.1(react@19.2.6)':
+    optionalDependencies:
+      react: 19.2.6
+
+  '@vercel/speed-insights@2.0.0(react@19.2.6)':
     optionalDependencies:
       react: 19.2.6
 

--- a/website/package.json
+++ b/website/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "@astrojs/starlight": "^0.40.0",
     "@dunky.dev/state-machine": "workspace:^",
-    "@vercel/analytics": "^2.0.1"
+    "@vercel/analytics": "^2.0.1",
+    "@vercel/speed-insights": "^2.0.0"
   },
   "devDependencies": {
     "@astrojs/mdx": "^6.0.3",

--- a/website/src/components/head.astro
+++ b/website/src/components/head.astro
@@ -4,7 +4,9 @@
 // mounts <Analytics /> directly in index.astro).
 import Default from '@astrojs/starlight/components/Head.astro'
 import Analytics from '@vercel/analytics/astro'
+import SpeedInsights from '@vercel/speed-insights/astro'
 ---
 
 <Default><slot /></Default>
 <Analytics />
+<SpeedInsights />

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -2,6 +2,7 @@
 import Header from "../components/header.astro";
 import Footer from "../components/footer.astro";
 import Analytics from "@vercel/analytics/astro";
+import SpeedInsights from "@vercel/speed-insights/astro";
 import "../styles/global.css";
 import { Code } from "@astrojs/starlight/components";
 import pacmanSrc from "../snippets/pacman.code.ts?raw";
@@ -766,6 +767,7 @@ const shareOnX = `https://twitter.com/intent/tweet?text=${encodeURIComponent(sha
     <Footer />
 
     <Analytics />
+    <SpeedInsights />
 
     <script>
       import {


### PR DESCRIPTION
Mount <SpeedInsights /> alongside the existing <Analytics />: in the Starlight Head override (covers all doc pages) and in the standalone homepage (index.astro).