### PR TITLE
feat(benchmark-demo): rework run modes and survival scoring

### DIFF
--- a/.changeset/benchmark-demo-survival-methodology.md
+++ b/.changeset/benchmark-demo-survival-methodology.md
@@ -1,0 +1,28 @@
+---
+'benchmark-demo': patch
+---
+
+Rework the live demo's two run modes and how it scores them.
+
+**Survival test** — ramp the load until every engine drowns, then stop:
+
+```
+load ▲                          ┌──────────────┐
+     │            ramps up      │ each engine: │
+     │         ───────────────▶ │ survived N/s │
+     │                          │ + N/ops      │
+     └──────────────────────────┴──────────────┘
+```
+
+**15s test** — run the full 15s, then rank by who lasted longest:
+
+```
+┌──────────┐  longest survivor   ┌──────────┐
+│  lib1    │ ──────────────────▶ │  faster  │ ✓ green
+├──────────┤                     ├──────────┤
+│  lib2    │ ──────────────────▶ │  slower  │ ✗ red
+└──────────┘                     └──────────┘
+```
+
+- **`updates/s`** is now a run-average (`totalApplied / totalElapsed`), shown as **% of vanilla** — the old last-250ms snapshot jumped around and tied fast engines with the control.
+- **"survived Ns"** replaces "fell behind by N": time-to-divergence ranks with speed (faster lasts longer).

--- a/benchmark/demo/src/app.tsx
+++ b/benchmark/demo/src/app.tsx
@@ -14,17 +14,28 @@ const RAMP_STEP = 1500
 const RAMP_EVERY_MS = 1200
 const PAINT_EVERY_MS = 100 // throttle canvas paint to ~10fps (off the hot path)
 const OVERFLOW_AT = 3000 // backlog over this = decisively "falling behind"
-const TEST_DURATION_MS = 30_000 // fixed-length "30s test" run
+const TEST_DURATION_MS = 15_000 // fixed-length "15s test" run
 
 const ENGINE_IDS: PanelId[] = ['Dunky', 'xstate', 'zag'] // raw doesn't count
 
 type Stat = {
   backlog: number
   appliedPerSec: number
-  // queued amount captured the moment this panel first overflowed (null = keeping up)
-  overflowedAt: number | null
+  // total updates this panel applied over the whole run (the "N ops" readout).
+  totalOps: number
+  // seconds this panel survived before its backlog crossed OVERFLOW_AT (null =
+  // never fell behind). Time-to-divergence is monotonic with engine speed — a
+  // faster engine holds the rising load longer — so it ranks the engines the
+  // same way updates/s does, unlike the backlog magnitude (which depended on the
+  // ramp rate at the divergence instant and read backwards).
+  fellBehindAtSec: number | null
 }
-const blankStat = (): Stat => ({ backlog: 0, appliedPerSec: 0, overflowedAt: null })
+const blankStat = (): Stat => ({
+  backlog: 0,
+  appliedPerSec: 0,
+  totalOps: 0,
+  fellBehindAtSec: null,
+})
 const zeroStats = (): Record<PanelId, Stat> => ({
   raw: blankStat(),
   Dunky: blankStat(),
@@ -40,6 +51,10 @@ export function App() {
   const [stats, setStats] = React.useState<Record<PanelId, Stat>>(zeroStats)
   // 0..1 remaining-time fraction during a 30s test (null = not a timed run)
   const [remaining, setRemaining] = React.useState<number | null>(null)
+  // true once a 30s test has run to completion — only THEN do we reveal the
+  // "fell behind by N" flags for a timed run (they're hidden mid-run so the
+  // coasting backlog doesn't read as a live verdict).
+  const [timedDone, setTimedDone] = React.useState(false)
 
   const size = side * side
   const feed = React.useMemo(() => createFeed(size), [size])
@@ -62,6 +77,7 @@ export function App() {
     setFps(0)
     setRate(0)
     setRemaining(null)
+    setTimedDone(false)
     setStats(zeroStats())
     // drop each panel's queue/applied state so the next run starts clean
     for (const id of Object.keys(handles.current) as PanelId[]) handles.current[id]?.clear()
@@ -83,9 +99,15 @@ export function App() {
     let lastSample = startedAt
     let lastPaint = startedAt
     let frames = 0
+    // per-sample applied (resets each 250ms window) — used for fps cadence only
     const applied: Record<PanelId, number> = { raw: 0, Dunky: 0, xstate: 0, zag: 0 }
-    // queued captured at first overflow, per panel (persists across samples)
-    const overflowedAt: Record<PanelId, number | null> = {
+    // run-long totals — the headline updates/s is totalApplied / totalElapsed, a
+    // RUNNING AVERAGE over the whole run. A last-250ms snapshot jumped around
+    // (and during Start, the stop-instant snapshot caught engines mid-divergence,
+    // making fast ones look tied with Vanilla); the average is stable.
+    const totalApplied: Record<PanelId, number> = { raw: 0, Dunky: 0, xstate: 0, zag: 0 }
+    // seconds-survived captured at first overflow, per panel (persists across samples)
+    const fellBehindAtSec: Record<PanelId, number | null> = {
       raw: null,
       Dunky: null,
       xstate: null,
@@ -105,6 +127,7 @@ export function App() {
           cancelAnimationFrame(loop.current)
           setRunning(false)
           setRemaining(0)
+          setTimedDone(true) // run complete → reveal the final "fell behind" flags
           return
         }
       }
@@ -112,7 +135,7 @@ export function App() {
       // Keep ramping the load only while at least one engine is still keeping up.
       // Once the last one falls behind we hold the rate steady — a timed run then
       // coasts at that frozen rate for the rest of the 30s.
-      const allBehind = ENGINE_IDS.every(id => overflowedAt[id] !== null)
+      const allBehind = ENGINE_IDS.every(id => fellBehindAtSec[id] !== null)
       if (!allBehind && now - lastRamp >= RAMP_EVERY_MS) {
         curRate += RAMP_STEP
         lastRamp = now
@@ -128,7 +151,10 @@ export function App() {
       // ~panels × budget). A sync engine's drain resolves without yielding.
       for (const id of ids) {
         const r = await handles.current[id]?.drain(DRAIN_BUDGET_MS)
-        if (r) applied[id] += r.applied
+        if (r) {
+          applied[id] += r.applied
+          totalApplied[id] += r.applied
+        }
       }
       // Stop may have been pressed during an await — bail before scheduling more.
       if (!runningRef.current) return
@@ -145,19 +171,28 @@ export function App() {
 
       if (t - lastSample >= 250) {
         const secs = (t - lastSample) / 1000
+        const totalSecs = (t - startedAt) / 1000 // whole run, for the running average
         setFps(Math.round(frames / secs))
         const next = zeroStats()
         for (const id of ids) {
           const backlog = handles.current[id]?.backlog() ?? 0
-          // once a panel crosses the line it's "behind"; track the WORST backlog
-          // it reaches (how many updates it ultimately couldn't keep up with)
-          if (backlog > OVERFLOW_AT) {
-            overflowedAt[id] = Math.max(overflowedAt[id] ?? 0, backlog)
+          // Latch HOW LONG the panel survived — the elapsed seconds at the first
+          // sample where backlog crossed the line — once, and never move it. The
+          // backlog MAGNITUDE at divergence is useless here: it depends on the ramp
+          // rate at the divergence instant (a fast engine diverges later, when the
+          // rate is higher, so it caught a BIGGER queue) — so it read backwards vs
+          // speed. Time-to-divergence is monotonic with speed: faster engines last
+          // longer. (Was Math.max backlog over time, which pinned every engine to
+          // the 500k queue cap during the coast.)
+          if (backlog > OVERFLOW_AT && fellBehindAtSec[id] === null) {
+            fellBehindAtSec[id] = (t - startedAt) / 1000
           }
           next[id] = {
             backlog,
-            appliedPerSec: Math.round(applied[id] / secs),
-            overflowedAt: overflowedAt[id],
+            // running average over the whole run — stable, doesn't jump per sample
+            appliedPerSec: totalSecs > 0 ? Math.round(totalApplied[id] / totalSecs) : 0,
+            totalOps: totalApplied[id],
+            fellBehindAtSec: fellBehindAtSec[id],
           }
           applied[id] = 0
         }
@@ -166,10 +201,9 @@ export function App() {
         lastSample = t
 
         // auto-stop the instant the LAST engine falls behind — freeze everything
-        // immediately so the "fell behind by N" flags reflect the moment of
-        // divergence and don't keep growing. A timed run ignores this and keeps
-        // going for the full duration.
-        if (!timed && ENGINE_IDS.every(id => overflowedAt[id] !== null)) {
+        // immediately so the flags reflect the moment of divergence. A timed run
+        // ignores this and keeps going for the full duration.
+        if (!timed && ENGINE_IDS.every(id => fellBehindAtSec[id] !== null)) {
           runningRef.current = false
           cancelAnimationFrame(loop.current)
           setRunning(false)
@@ -226,9 +260,9 @@ export function App() {
           that feeds a computed. One change stream feeds all four; each gets an equal{' '}
           <b>{DRAIN_BUDGET_MS}ms/frame</b> to apply its queue, and the load ramps until they
           diverge. The grid is a throttled canvas heatmap (paint kept off the hot path), so what
-          you're watching is <b>engine cost</b>. <b>Start</b> runs until all three engines fall
-          behind, then stops; <b>30s test</b> runs the full half-minute regardless. Idle until you
-          start.
+          you're watching is <b>engine cost</b>. <b>Survival test</b> runs until all three engines
+          fall behind, then stops; <b>15s test</b> runs the full fifteen seconds regardless. Idle
+          until you start.
         </p>
       </header>
 
@@ -245,23 +279,6 @@ export function App() {
         }}
       >
         <button
-          onClick={() => start(false)}
-          style={{
-            padding: '8px 18px',
-            fontSize: 14,
-            fontWeight: 600,
-            cursor: 'pointer',
-            borderRadius: 6,
-            border: 'none',
-            background: running ? '#da3633' : '#238636',
-            color: 'white',
-            minWidth: 90,
-          }}
-        >
-          🏁 {running ? 'Stop' : 'Start'}
-        </button>
-
-        <button
           onClick={() => start(true)}
           disabled={running}
           style={{
@@ -276,7 +293,24 @@ export function App() {
             opacity: running ? 0.4 : 1,
           }}
         >
-          ⏱️ 30s test
+          ⏱️ 15s test
+        </button>
+
+        <button
+          onClick={() => start(false)}
+          style={{
+            padding: '8px 18px',
+            fontSize: 14,
+            fontWeight: 600,
+            cursor: 'pointer',
+            borderRadius: 6,
+            border: 'none',
+            background: running ? '#da3633' : '#238636',
+            color: 'white',
+            minWidth: 90,
+          }}
+        >
+          ☠️ {running ? 'Stop' : 'Survival test'}
         </button>
 
         <label style={{ fontSize: 13 }}>
@@ -319,67 +353,136 @@ export function App() {
       </div>
 
       <p style={{ margin: '0 0 16px', fontSize: 12, opacity: 0.55, maxWidth: 1000 }}>
-        <b>updates/s</b> is the headline — how much engine work each clears under the same{' '}
-        {DRAIN_BUDGET_MS}ms/frame budget (higher is better). The moment a panel can't keep up it
-        latches a red <b>fell behind by N</b> flag (the backlog it had stacked up). Watch the panels
-        diverge as the load ramps. <b>Vanilla</b> is the control (no engine); the comparison that
-        matters is Dunky vs XState vs Zag.
+        <b>updates/s</b> is the headline — the run-average engine work each clears under the same{' '}
+        {DRAIN_BUDGET_MS}ms/frame budget (higher is better), shown as a <b>% of vanilla</b> (the
+        control). The <b>15s test</b> runs the full fifteen seconds and crowns the engine that{' '}
+        <b>survived</b> the rising load longest <b style={{ color: '#3fb950' }}>faster</b>, the rest{' '}
+        <b style={{ color: '#f85149' }}>slower</b>. The <b>survival test</b> ramps until every
+        engine falls behind, reporting how long each lasted and how many ops it applied.{' '}
+        <b>Vanilla</b> is the control; the comparison that matters is Dunky vs XState vs Zag.
       </p>
 
-      {/* auto-fit + minmax so the four panels wrap to fewer columns as the
-          viewport narrows (4 → 2 → 1) instead of overflowing past the edge on
-          phones/tablets. Pure CSS grid — no media query needed. */}
-      <div
-        style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))',
-          gap: 12,
-        }}
-      >
-        {PANELS.map(p => {
-          const s = stats[p.id]
-          const behind = s.overflowedAt !== null
-          return (
-            <div
-              key={`${p.id}-${side}`}
-              style={{
-                border: `1px solid ${behind ? '#f85149' : '#30363d'}`,
-                borderRadius: 8,
-                padding: 12,
-                background: '#0d1117',
-                transition: 'border-color 200ms',
-              }}
-            >
-              <div
-                style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}
-              >
-                <strong style={{ fontSize: 14 }}>{p.label}</strong>
-                <span style={{ fontSize: 12 }}>
-                  <b style={{ color: '#58a6ff' }}>{s.appliedPerSec.toLocaleString()}</b>
-                  <span style={{ opacity: 0.6 }}> updates/s</span>
-                  {behind && (
-                    <span style={{ color: '#f85149', fontWeight: 600 }}>
-                      {' '}
-                      · fell behind by {(s.overflowedAt ?? 0).toLocaleString()}
-                    </span>
+      {/* The 30s test's verdict, computed once the run completes: the ENGINE that
+          survived the rising load longest is the winner (green · "faster"); the
+          rest are red · "slower". Vanilla is the control and is excluded from the
+          ranking — it's the 100% baseline every panel's % diff is measured against. */}
+      {(() => {
+        const timedVerdict = remaining !== null && timedDone
+        const bestEngine = timedVerdict
+          ? ENGINE_IDS.reduce<PanelId | null>((best, id) => {
+              const t = stats[id].fellBehindAtSec ?? -1
+              return best === null || t > (stats[best].fellBehindAtSec ?? -1) ? id : best
+            }, null)
+          : null
+        const vanillaOps = stats.raw.appliedPerSec
+
+        // auto-fit + minmax so the four panels wrap to fewer columns as the
+        // viewport narrows (4 → 2 → 1) instead of overflowing past the edge on
+        // phones/tablets. Pure CSS grid — no media query needed.
+        return (
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))',
+              gap: 12,
+            }}
+          >
+            {PANELS.map(p => {
+              const s = stats[p.id]
+              // A timed (30s) run hides the survival flag WHILE running — the coasting
+              // backlog mid-run isn't the verdict — and reveals it only once the run
+              // completes. An untimed run shows it live (it auto-stops at the moment of
+              // divergence, so the flag is the verdict the instant it appears).
+              const isTimedRun = remaining !== null
+              const showBehind = !isTimedRun || timedDone
+              const behind = showBehind && s.fellBehindAtSec !== null
+
+              // 30s verdict colouring: winner green, every other ENGINE red. Vanilla
+              // (the control) and the live survival test keep the neutral treatment.
+              const isWinner = timedVerdict && p.id === bestEngine
+              const isLoser = timedVerdict && p.isEngine && p.id !== bestEngine
+              const borderColor = isWinner ? '#3fb950' : isLoser || behind ? '#f85149' : '#30363d'
+
+              // % vs Vanilla — always relative to the control's updates/s.
+              const pctVsVanilla =
+                p.isEngine && vanillaOps > 0
+                  ? Math.round((s.appliedPerSec / vanillaOps) * 100)
+                  : null
+
+              return (
+                <div
+                  key={`${p.id}-${side}`}
+                  style={{
+                    border: `1px solid ${borderColor}`,
+                    borderRadius: 8,
+                    padding: 12,
+                    background: '#0d1117',
+                    transition: 'border-color 200ms',
+                  }}
+                >
+                  {/* Results stacked on their own lines above the square — each
+                      metric on a break so the panel reads top-to-bottom instead of
+                      one cramped inline row. */}
+                  <div
+                    style={{
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      alignItems: 'baseline',
+                    }}
+                  >
+                    <strong style={{ fontSize: 14 }}>{p.label}</strong>
+                    {isWinner && (
+                      <span style={{ color: '#3fb950', fontWeight: 700, fontSize: 13 }}>
+                        faster
+                      </span>
+                    )}
+                    {isLoser && (
+                      <span style={{ color: '#f85149', fontWeight: 700, fontSize: 13 }}>
+                        slower
+                      </span>
+                    )}
+                  </div>
+                  <div style={{ fontSize: 13, marginTop: 4 }}>
+                    <b style={{ color: '#58a6ff' }}>{s.appliedPerSec.toLocaleString()}</b>
+                    <span style={{ opacity: 0.6 }}> updates/s</span>
+                  </div>
+                  {pctVsVanilla !== null && (
+                    <div style={{ fontSize: 12, opacity: 0.6 }}>{pctVsVanilla}% of vanilla</div>
                   )}
-                </span>
-              </div>
-              <div style={{ fontSize: 11, opacity: 0.55, margin: '2px 0 10px', height: 16 }}>
-                {p.blurb}
-              </div>
-              <Panel
-                ref={el => {
-                  handles.current[p.id] = el
-                }}
-                id={p.id}
-                side={side}
-                feed={feed}
-              />
-            </div>
-          )
-        })}
-      </div>
+                  {/* live survival test: how long it lasted + total ops applied */}
+                  {behind && !timedVerdict && (
+                    <div style={{ fontSize: 12, color: '#f85149', fontWeight: 600 }}>
+                      survived {(s.fellBehindAtSec ?? 0).toFixed(1)}s ·{' '}
+                      {s.totalOps.toLocaleString()} ops
+                    </div>
+                  )}
+                  {/* timed verdict: how long each survived the rising load */}
+                  {behind && timedVerdict && (
+                    <div
+                      style={{
+                        fontSize: 12,
+                        color: isWinner ? '#3fb950' : '#f85149',
+                        fontWeight: 600,
+                      }}
+                    >
+                      survived {(s.fellBehindAtSec ?? 0).toFixed(1)}s
+                    </div>
+                  )}
+                  <div style={{ fontSize: 11, opacity: 0.55, margin: '8px 0 10px' }}>{p.blurb}</div>
+                  <Panel
+                    ref={el => {
+                      handles.current[p.id] = el
+                    }}
+                    id={p.id}
+                    side={side}
+                    feed={feed}
+                  />
+                </div>
+              )
+            })}
+          </div>
+        )
+      })()}
     </div>
   )
 }


### PR DESCRIPTION
Reworks the live benchmark demo's two run modes and how it scores engines.

## Modes
- **15s test** (was `30s test`) — runs the full 15s, then crowns the engine that survived the rising load longest **faster** (green), the rest **slower** (red). Vanilla is the baseline, not ranked.
- **Survival test** (was `Start`) — ramps the load until every engine drowns, then stops.

## Metric changes
- **`updates/s` is now a run-average** (`totalApplied / totalElapsed`), shown as **% of vanilla**. The old last-250ms snapshot jumped around and tied fast engines with the control.
- **"survived Ns"** replaces "fell behind by N" — time-to-divergence ranks with speed (faster lasts longer); the old backlog magnitude read backwards and pinned to the 500k queue cap.
- Per-panel results stack on their own lines above each heatmap for readability.

Changeset included (`benchmark-demo` patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)