### PR TITLE
feat(website): mark external links with a trailing arrow

### DIFF
--- a/website/src/content/docs/benchmark.mdx
+++ b/website/src/content/docs/benchmark.mdx
@@ -15,7 +15,7 @@ import { Aside } from '@astrojs/starlight/components'
 
 The hard case is **thousands of machines reacting to thousands of events inside one frame budget**: trading terminals, live order books, monitoring walls, dense collaborative canvases. That's what this engine is built for.
 
-**▶ [Watch it live](https://dunky-dev.github.io/state-machine/):** all three engines driving a real grid in your browser. Watch which ones fall behind as the load climbs.
+**▶ <a href="https://dunky-dev.github.io/state-machine/" target="_blank" rel="noopener">Watch it live</a>:** all three engines driving a real grid in your browser. Watch which ones fall behind as the load climbs.
 
 ## The trade-off
 

--- a/website/src/styles/starlight.css
+++ b/website/src/styles/starlight.css
@@ -30,3 +30,14 @@
   font-weight: 700;
   letter-spacing: -0.01em;
 }
+
+/* External links (target="_blank") get a trailing ↗ so it's clear they leave
+ * the site. The glyph is non-selectable and inherits the link color. */
+.sl-markdown-content a[target='_blank']::after {
+  content: '\2197'; /* ↗ */
+  display: inline-block;
+  margin-inline-start: 0.15em;
+  font-size: 0.85em;
+  line-height: 1;
+  user-select: none;
+}


### PR DESCRIPTION
- Open the benchmark **Watch it live** link in a new tab (`target="_blank" rel="noopener"`).
- Add a global rule in `starlight.css` that appends a ↗ after any `target="_blank"` link inside `.sl-markdown-content`, so it's visually clear the link leaves the site (scoped to doc body content — not nav/sidebar/footer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)