### PR TITLE
feat: serve the benchmark demo at dunky.dev/state-machine/benchmark/demo

### DIFF
--- a/.github/workflows/deploy-benchmark.yml
+++ b/.github/workflows/deploy-benchmark.yml
@@ -34,11 +34,12 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build demo
-        # GitHub Pages hosts the demo, but it's surfaced to users via a Vercel
-        # rewrite at dunky.dev/state-machine/benchmark (see website/vercel.json),
-        # so assets must resolve under that same path.
+        # The canonical demo ships with the docs site at
+        # dunky.dev/state-machine/benchmark/demo (bundled into the Astro dist;
+        # see website/package.json). This Pages deploy is a standalone mirror at
+        # the same path, so the base must match.
         env:
-          BASE_PATH: /state-machine/benchmark/
+          BASE_PATH: /state-machine/benchmark/demo/
         run: pnpm -C benchmark/demo build
 
       - uses: actions/configure-pages@v5

--- a/.github/workflows/deploy-benchmark.yml
+++ b/.github/workflows/deploy-benchmark.yml
@@ -34,10 +34,11 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build demo
-        # base must match the repo name so asset URLs resolve under
-        # https://dunky-dev.github.io/state-machine/
+        # GitHub Pages hosts the demo, but it's surfaced to users via a Vercel
+        # rewrite at dunky.dev/state-machine/benchmark (see website/vercel.json),
+        # so assets must resolve under that same path.
         env:
-          BASE_PATH: /state-machine/
+          BASE_PATH: /state-machine/benchmark/
         run: pnpm -C benchmark/demo build
 
       - uses: actions/configure-pages@v5

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ engine is built for it:
 → **~8× XState's throughput**, on par with XState for memory but at least **3× lighter than Zag** — and the gap widens as context grows, because memory stays ~flat in field count (no per-field cell). ᵃ Zag uses async ops, so a synchronous ops/s loop can't time it. Full methodology + per-scenario tables in the
 **[benchmark README](./benchmark/README.md)**.
 
-**▶ [Try the live benchmark demo](https://dunky.dev/state-machine/benchmark)** — watch all three engines run in your browser.
+**▶ [Try the live benchmark demo](https://dunky.dev/state-machine/benchmark/demo)** — watch all three engines run in your browser.
 
 ## How it's built
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ engine is built for it:
 → **~8× XState's throughput**, on par with XState for memory but at least **3× lighter than Zag** — and the gap widens as context grows, because memory stays ~flat in field count (no per-field cell). ᵃ Zag uses async ops, so a synchronous ops/s loop can't time it. Full methodology + per-scenario tables in the
 **[benchmark README](./benchmark/README.md)**.
 
-**▶ [Try the live benchmark demo](https://dunky-dev.github.io/state-machine/)** — watch all three engines run in your browser.
+**▶ [Try the live benchmark demo](https://dunky.dev/state-machine/benchmark)** — watch all three engines run in your browser.
 
 ## How it's built
 

--- a/benchmark/demo/vite.config.ts
+++ b/benchmark/demo/vite.config.ts
@@ -3,8 +3,9 @@ import react from '@vitejs/plugin-react'
 import { resolve } from 'node:path'
 
 export default defineConfig({
-  // On GitHub Pages the site is served from /state-machine/; locally it's /.
-  // The deploy workflow sets BASE_PATH=/state-machine/ for the Pages build.
+  // Locally served from /; in prod the deploy workflow sets BASE_PATH to
+  // /state-machine/benchmark/ so assets match the dunky.dev rewrite path
+  // (see deploy-benchmark.yml and website/vercel.json).
   base: process.env.BASE_PATH ?? '/',
   plugins: [react()],
   resolve: {

--- a/benchmark/demo/vite.config.ts
+++ b/benchmark/demo/vite.config.ts
@@ -3,10 +3,13 @@ import react from '@vitejs/plugin-react'
 import { resolve } from 'node:path'
 
 export default defineConfig({
-  // Locally served from /; in prod the deploy workflow sets BASE_PATH to
-  // /state-machine/benchmark/ so assets match the dunky.dev rewrite path
-  // (see deploy-benchmark.yml and website/vercel.json).
+  // Locally served from /; in prod the demo is mounted under the docs site at
+  // dunky.dev/state-machine/benchmark/demo, so BASE_PATH is set to that path
+  // (see website/package.json build and .github/workflows/deploy-benchmark.yml).
   base: process.env.BASE_PATH ?? '/',
+  // The website build (Vercel) redirects the output into the Astro dist so the
+  // demo ships as same-origin static files; OUT_DIR carries that target.
+  build: process.env.OUT_DIR ? { outDir: process.env.OUT_DIR, emptyOutDir: true } : undefined,
   plugins: [react()],
   resolve: {
     // the engine package is workspace-linked; aliasing straight to its `src`

--- a/website/astro.config.ts
+++ b/website/astro.config.ts
@@ -40,7 +40,10 @@ function rehypeBaseLinks() {
 
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://dunky-dev.github.io',
+  // Canonical host: dunky.dev 308-redirects to www, so www is the real origin.
+  // This drives canonical links, og:url, and the sitemap — must be the user-
+  // facing domain, not the github.io Pages mirror.
+  site: 'https://www.dunky.dev',
   base,
   // Vercel serves the static output only at slash-less paths (`/api/context`);
   // the trailing-slash variant 404s. `'never'` makes Astro emit slash-less

--- a/website/package.json
+++ b/website/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "astro dev",
-    "build": "astro build && pnpm build:demo",
-    "build:demo": "BASE_PATH=/state-machine/benchmark/demo/ OUT_DIR=../../website/dist/state-machine/benchmark/demo pnpm -C ../benchmark/demo build",
+    "build": "astro build && pnpm build:benchmark-demo",
+    "build:benchmark-demo": "BASE_PATH=/state-machine/benchmark/demo/ OUT_DIR=../../website/dist/state-machine/benchmark/demo pnpm -C ../benchmark/demo build",
     "preview": "astro preview",
     "astro": "astro"
   },

--- a/website/package.json
+++ b/website/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "astro dev",
-    "build": "astro build",
+    "build": "astro build && pnpm build:demo",
+    "build:demo": "BASE_PATH=/state-machine/benchmark/demo/ OUT_DIR=../../website/dist/state-machine/benchmark/demo pnpm -C ../benchmark/demo build",
     "preview": "astro preview",
     "astro": "astro"
   },

--- a/website/src/content/docs/benchmark.mdx
+++ b/website/src/content/docs/benchmark.mdx
@@ -15,7 +15,7 @@ import { Aside } from '@astrojs/starlight/components'
 
 The hard case is **thousands of machines reacting to thousands of events inside one frame budget**: trading terminals, live order books, monitoring walls, dense collaborative canvases. That's what this engine is built for.
 
-**▶ <a href="https://dunky-dev.github.io/state-machine/" target="_blank" rel="noopener">Watch it live</a>:** all three engines driving a real grid in your browser. Watch which ones fall behind as the load climbs.
+**▶ <a href="/state-machine/benchmark/demo">Watch it live</a>:** all three engines driving a real grid in your browser. Watch which ones fall behind as the load climbs.
 
 ## The trade-off
 

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -2,6 +2,9 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "redirects": [{ "source": "/", "destination": "/state-machine", "permanent": false }],
   "rewrites": [
+    { "source": "/state-machine/benchmark", "destination": "https://dunky-dev.github.io/state-machine/benchmark/" },
+    { "source": "/state-machine/benchmark/", "destination": "https://dunky-dev.github.io/state-machine/benchmark/" },
+    { "source": "/state-machine/benchmark/:path*", "destination": "https://dunky-dev.github.io/state-machine/benchmark/:path*" },
     { "source": "/state-machine", "destination": "/index.html" },
     { "source": "/state-machine/", "destination": "/index.html" },
     { "source": "/state-machine/:path*", "destination": "/:path*" }

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -2,9 +2,8 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "redirects": [{ "source": "/", "destination": "/state-machine", "permanent": false }],
   "rewrites": [
-    { "source": "/state-machine/benchmark", "destination": "https://dunky-dev.github.io/state-machine/benchmark/" },
-    { "source": "/state-machine/benchmark/", "destination": "https://dunky-dev.github.io/state-machine/benchmark/" },
-    { "source": "/state-machine/benchmark/:path*", "destination": "https://dunky-dev.github.io/state-machine/benchmark/:path*" },
+    { "source": "/state-machine/benchmark/demo", "destination": "/state-machine/benchmark/demo/index.html" },
+    { "source": "/state-machine/benchmark/demo/", "destination": "/state-machine/benchmark/demo/index.html" },
     { "source": "/state-machine", "destination": "/index.html" },
     { "source": "/state-machine/", "destination": "/index.html" },
     { "source": "/state-machine/:path*", "destination": "/:path*" }


### PR DESCRIPTION
## Problem

The **"watch it live"** demo link pointed at `https://dunky-dev.github.io/state-machine/`, which browsers flag as a **lookalike** of the real `dunky.dev` domain.

## Fix

Build the interactive demo **into the docs site's own Vercel output** and serve it as same-origin static files at **`dunky.dev/state-machine/benchmark/demo`** — a new sub-path that leaves the existing `/state-machine/benchmark` methodology page untouched.

This was chosen over a Vercel proxy/rewrite to the GitHub Pages deploy, which carried real, hard-to-verify failure modes: external-origin rewrite support, cross-origin redirects from Pages' trailing-slash behavior, runtime asset paths, and a deploy-order race.

## Changes

- **website/package.json** — build now runs `astro build && build:demo`, building the demo with `BASE_PATH=/state-machine/benchmark/demo/` and `OUT_DIR` into the Astro dist. Vercel runs the website build, so the demo ships automatically.
- **benchmark/demo/vite.config.ts** — honors `OUT_DIR`; base/outDir stay defaults locally so `vite dev`/`build` are unchanged.
- **website/vercel.json** — map the bare demo path to its bundled index.html, before the `/state-machine` catch-all. No external proxy.
- **.github/workflows/deploy-benchmark.yml** — kept as a Pages mirror at the new `/demo` path.
- **README.md** — link to `/state-machine/benchmark/demo`.

## Verified locally

- `pnpm -C website build` bundles the demo into `dist/state-machine/benchmark/demo/`.
- Demo assets resolve under `/state-machine/benchmark/demo/...` (same origin).
- Existing `/state-machine/benchmark` docs page is present and distinct from the demo.
- Local demo build (no env) unchanged: base `/`, own dist.

No external dependencies, no deploy race, no custom domain/DNS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)