### PR TITLE
Fix dark-theme favicon (white variant via <link media>)

### DIFF
--- a/website/astro.config.ts
+++ b/website/astro.config.ts
@@ -56,7 +56,21 @@ export default defineConfig({
   integrations: [
     starlight({
       title: 'Dunky',
+      // Light/default favicon (Starlight base-prefixes this one). Chrome ignores
+      // prefers-color-scheme *inside* an SVG favicon, so the dark-tab white
+      // variant is supplied as a separate <link media> in `head` below.
       favicon: '/logo/logo-symbol.svg',
+      head: [
+        {
+          tag: 'link',
+          attrs: {
+            rel: 'icon',
+            type: 'image/svg+xml',
+            href: `${basePrefix}/logo/logo-symbol-white.svg`,
+            media: '(prefers-color-scheme: dark)',
+          },
+        },
+      ],
       logo: {
         light: './public/logo/logo.svg',
         dark: './public/logo/logo-white.png',


### PR DESCRIPTION
The favicon stayed black on dark browser tab bars because Chrome ignores the `prefers-color-scheme` media query *inside* an SVG favicon.

## Fix
- Bumps the `logo` submodule to pick up the new `logo-symbol-white.svg`.
- Adds a dark-mode favicon override via Starlight's `head` config:
  `<link rel="icon" type="image/svg+xml" href="/state-machine/logo/logo-symbol-white.svg" media="(prefers-color-scheme: dark)">`
- Keeps Starlight's existing `favicon` as the light/default (and fallback for browsers that ignore `media` on icon links).

Same fix applied to the `website` and `template-repo` repos for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)