### PR TITLE
perf(core): memoize the select builder per machine

### DIFF
--- a/.changeset/memoize-select-builder.md
+++ b/.changeset/memoize-select-builder.md
@@ -1,0 +1,5 @@
+---
+'@dunky.dev/state-machine': patch
+---
+
+Memoize the `select` builder per machine. `machine.select` was a getter that rebuilt the whole builder — the callable plus its `.context`/`.computed`/`.state` scope methods, and a fresh `.bind` pair for the bus mutators — on **every** access, so `machine.select.context(k).subscribe(...)` allocated several throwaway objects per call. Since the builder closes only over the machine (identity permanent), it's now built once and cached: `machine.select` returns a stable reference across reads, and the shared bound bus mutators are reused by every `Selection`. A leaf list that calls `machine.select(...)` once per row on mount (the React adapter's `useSelector`) now allocates far less per mount; an isolated micro-bench of the per-row `select.context(k).subscribe()` shape runs ~1.9× faster. No behavior change beyond `select`'s now-stable identity.

--- a/packages/core/src/machine.ts
+++ b/packages/core/src/machine.ts
@@ -85,6 +85,16 @@ class MachineClass<
   send: (event: Event) => void
   // live params + named registries that runAction(s) read (built once in the ctor)
   actionHost: ActionHost<Context, Event, Computed>
+  // The `select` builder is built once, lazily, and cached: it closes only over
+  // `this` (identity permanent), so re-deriving it — plus its three scope methods
+  // — on every `.select` access was pure garbage. A leaf list calls
+  // `machine.select(...)` once per row on mount, so the per-access allocation hit
+  // the engine's hottest integration path; this makes repeated reads free.
+  selectBuilder: Select<State, Context, Computed> | null = null
+  // Stable bound bus mutators, shared by every Selection built off this machine
+  // (makeSelection used to `.bind` a fresh pair per selection).
+  boundBusAdd: (l: () => void) => void
+  boundBusDelete: (l: () => void) => void
 
   constructor(config: TransitionConfig<State, Context, Event, Computed>) {
     this.config = config
@@ -137,6 +147,9 @@ class MachineClass<
       this.bump()
     }
     this.send = event => this.doSend(event)
+    // Bind once; every Selection reuses these instead of binding a fresh pair.
+    this.boundBusAdd = this.busAdd.bind(this)
+    this.boundBusDelete = this.busDelete.bind(this)
   }
 
   // ---- kernel notify ----
@@ -438,8 +451,8 @@ class MachineClass<
   // listener only when the selected value changes (Object.is default / equals).
   // `value` is a plain eval. No fire on subscribe.
   private makeSelection<Value>(selector: () => Value): Selection<Value> {
-    const add = this.busAdd.bind(this)
-    const remove = this.busDelete.bind(this)
+    const add = this.boundBusAdd
+    const remove = this.boundBusDelete
     return {
       get value() {
         return selector()
@@ -458,6 +471,7 @@ class MachineClass<
     }
   }
   get select(): Select<State, Context, Computed> {
+    if (this.selectBuilder) return this.selectBuilder
     const sel = (<Value>(selector: () => Value) => this.makeSelection(selector)) as Select<
       State,
       Context,
@@ -467,7 +481,7 @@ class MachineClass<
     sel.computed = <K extends keyof Computed>(key: K) =>
       this.makeSelection(() => this.computed[key])
     sel.state = () => this.makeSelection(() => this.stateValue)
-    return sel
+    return (this.selectBuilder = sel)
   }
 }
 

--- a/packages/core/tests/subscribe.test.ts
+++ b/packages/core/tests/subscribe.test.ts
@@ -308,6 +308,72 @@ describe('select.context / .computed / .state — named scopes', () => {
   })
 })
 
+// The `select` builder is memoized per machine (built once, cached): it closes
+// only over the machine, whose identity never changes, so re-deriving it — and
+// its three scope methods — on every read was pure garbage. These pin the
+// observable contract (stable identity) AND prove the memo + the shared bound
+// bus mutators didn't break per-selection independence.
+describe('select — memoized builder', () => {
+  const counter = () =>
+    machine<'idle', { a: number; b: number }, { type: 'bumpA' | 'bumpB' }>({
+      initial: 'idle',
+      context: { a: 0, b: 0 },
+      states: {
+        idle: {
+          on: {
+            bumpA: { actions: [({ context, setContext }) => setContext({ a: context.a + 1 })] },
+            bumpB: { actions: [({ context, setContext }) => setContext({ b: context.b + 1 })] },
+          },
+        },
+      },
+    })
+
+  it('returns the same builder object across reads', () => {
+    const m = counter()
+    expect(m.select).toBe(m.select)
+  })
+
+  it('the named scope methods keep a stable identity across reads', () => {
+    const m = counter()
+    expect(m.select.context).toBe(m.select.context)
+    expect(m.select.computed).toBe(m.select.computed)
+    expect(m.select.state).toBe(m.select.state)
+  })
+
+  it('distinct machines get distinct builders (no cross-instance sharing)', () => {
+    const a = counter()
+    const b = counter()
+    expect(a.select).not.toBe(b.select)
+  })
+
+  it('two selections off the cached builder fire independently and dedup per-field', () => {
+    const m = counter()
+    const aFn = vi.fn()
+    const bFn = vi.fn()
+    m.select.context('a').subscribe(aFn)
+    m.select.context('b').subscribe(bFn)
+    m.send({ type: 'bumpA' }) // only `a` changed
+    expect(aFn).toHaveBeenCalledTimes(1)
+    expect(bFn).not.toHaveBeenCalled() // shared bound add/remove must not cross-wire
+    m.send({ type: 'bumpB' }) // only `b` changed
+    expect(aFn).toHaveBeenCalledTimes(1)
+    expect(bFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('unsubscribing one selection leaves the other live (shared bus mutators)', () => {
+    const m = counter()
+    const aFn = vi.fn()
+    const bFn = vi.fn()
+    const offA = m.select.context('a').subscribe(aFn)
+    m.select.context('b').subscribe(bFn)
+    offA() // remove only A's listener via the shared boundBusDelete
+    m.send({ type: 'bumpA' })
+    expect(aFn).not.toHaveBeenCalled() // A is gone
+    m.send({ type: 'bumpB' })
+    expect(bFn).toHaveBeenCalledTimes(1) // B unaffected
+  })
+})
+
 // The bus iterates a stable snapshot with a live-membership check: a listener
 // ADDED mid-notify first fires on the next pass; a listener REMOVED mid-notify
 // is skipped immediately (unsubscribe takes effect at once).

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,6 @@ export default defineConfig({
   test: {
     globals: false,
     environment: 'node',
-    exclude: ['**/node_modules/**', '**/dist/**'],
+    exclude: ['**/node_modules/**', '**/dist/**', '**/.worktrees/**', '**/.{git,cache}/**'],
   },
 })


### PR DESCRIPTION
## What

`machine.select` was a **getter** that rebuilt the entire builder on every access:

- the callable `select(fn)` form,
- its three scope methods `.context` / `.computed` / `.state` (re-assigned as fresh closures),
- and inside `makeSelection`, a fresh `.bind` pair for the bus mutators.

So `machine.select.context(k).subscribe(...)` allocated a builder object + 3 discarded scope closures + 2 bound functions **per call** — on the engine's hottest integration path. The React adapter's `useSelector` calls `machine.select(...)` once per row, so a 1000-row list paid this ~1000× on mount.

The builder closes only over the machine, whose identity is permanent, so there's nothing to rebuild. This builds it **once, lazily, and caches it**:

- `machine.select` now returns a **stable reference** across reads (and `.context`/`.computed`/`.state` are stable too),
- the bound bus mutators (`boundBusAdd`/`boundBusDelete`) are created once in the ctor and reused by every `Selection`.

## Measurement

Isolated micro-bench of the per-row `select.context(k).subscribe()` shape (same process, old builder reconstructed inline vs. new memoized path):

| | ops/sec | mean |
|---|--:|--:|
| **old** (rebuilt builder) | 1.09 M | 913 ns |
| **new** (memoized) | **2.12 M** | **471 ns** |

≈ **1.9× faster**, ~443 ns saved per call.

The suite's `tinybench` ops/sec loops are **unchanged** — the allocation was setup-time (subscriptions are built before the timed window), so those numbers correctly don't move (verified: fan-out / throughput / fine-grain all within ±rme of baseline). The React rendering `selector` mount times nudged the right way (1000-row mount 7.7 → 7.4 ms; jsdom render dominates the macro wall-clock).

## Behavior

No behavior change beyond `select`'s now-stable identity. All 312 workspace tests pass, including 5 new ones in `subscribe.test.ts` pinning the identity contract and proving the shared bound mutators didn't cross-wire or break per-selection unsubscribe.

## Also

Excludes `.worktrees/**` from the root `vitest` config — sibling-branch git worktrees were being swept into this checkout's test run (12 spurious file failures on missing deps / vite JSX config, unrelated to any change here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)