### PR TITLE
refactor!: rename framework adapters to substrate-prefix convention

### DIFF
--- a/.changeset/rename-adapters-to-prefix.md
+++ b/.changeset/rename-adapters-to-prefix.md
@@ -1,0 +1,45 @@
+---
+'@dunky.dev/react-state-machine': minor
+'@dunky.dev/native-state-machine': minor
+'@dunky.dev/opentui-state-machine': minor
+---
+
+Rename the framework adapters back to a `*-state-machine` substrate-prefix convention.
+
+We tried the `state-machine-*` suffix convention (see the previous rename) to
+keep the whole `@dunky.dev/*` scope alphabetically consistent. In practice it
+proved ergonomically wrong once you picture it scaled to more than one
+package family:
+
+```
+suffix (tried):        prefix (this change):
+button-react            react-button
+dropdown-react          react-dropdown
+state-machine-react     react-state-machine
+```
+
+Picture browsing npm under `@dunky.dev/react-*` — every React package for
+this scope, together, in one look. That's the whole point of an org scope:
+someone building a React app should be able to find everything React-related
+under `@dunky.dev/react-*`. The suffix form breaks that; `button-react`,
+`dropdown-react`, and `state-machine-react` don't show up together anywhere,
+because "react" isn't what they're named _by_.
+
+It reads backwards at the import site too —
+`import { useMachine } from '@dunky.dev/state-machine-react'` names the
+library before the framework, when every other adapter a React codebase
+imports (`react-redux`, `react-query`, `react-hook-form`) names the framework
+first.
+
+- `@dunky.dev/state-machine-react` → `@dunky.dev/react-state-machine`
+- `@dunky.dev/state-machine-native` → `@dunky.dev/native-state-machine`
+- `@dunky.dev/state-machine-opentui` → `@dunky.dev/opentui-state-machine`
+
+The previous suffix-named packages are deprecated on npm in favor of these.
+
+```diff
+- import { useMachine } from '@dunky.dev/state-machine-react'
++ import { useMachine } from '@dunky.dev/react-state-machine'
+```
+
+`@dunky.dev/state-machine` (core), `@dunky.dev/state-machine-utils`, and `@dunky.dev/state-machine-bindings` are unchanged — they aren't tied to one substrate, so the prefix convention doesn't apply to them.

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@dunky.dev/state-machine": "workspace:^",
-    "@dunky.dev/state-machine-react": "workspace:^"
+    "@dunky.dev/react-state-machine": "workspace:^"
   },
   "devDependencies": {
     "@types/jsdom": "^21.1.7",

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -7,8 +7,8 @@
     "benchmark": "NODE_ENV=production node --expose-gc --import tsx index.ts"
   },
   "dependencies": {
-    "@dunky.dev/state-machine": "workspace:^",
-    "@dunky.dev/react-state-machine": "workspace:^"
+    "@dunky.dev/react-state-machine": "workspace:^",
+    "@dunky.dev/state-machine": "workspace:^"
   },
   "devDependencies": {
     "@types/jsdom": "^21.1.7",

--- a/benchmark/tests/rendering/bench.tsx
+++ b/benchmark/tests/rendering/bench.tsx
@@ -37,7 +37,7 @@ import {
 } from 'xstate'
 import { useSelector as useXSelector } from '@xstate/react'
 import { machine, type Machine } from '@dunky.dev/state-machine'
-import { useSelector } from '@dunky.dev/state-machine-react'
+import { useSelector } from '@dunky.dev/react-state-machine'
 
 type Ctx = { highlighted: number }
 type Ev = { type: 'move'; to: number }

--- a/benchmark/tsconfig.json
+++ b/benchmark/tsconfig.json
@@ -6,8 +6,8 @@
     // paths in `extends` resolve relative to THIS file, so redeclare them
     "paths": {
       "@dunky.dev/state-machine": ["../packages/core/src"],
-      "@dunky.dev/state-machine-react": ["../packages/react/src"],
-      "@dunky.dev/state-machine-native": ["../packages/native/src"],
+      "@dunky.dev/react-state-machine": ["../packages/react/src"],
+      "@dunky.dev/native-state-machine": ["../packages/native/src"],
       "@dunky.dev/state-machine-utils": ["../packages/shared/utils/src"]
     },
     // the benchmark touches Node globals (process, global) + DOM (jsdom, react-dom)

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@dunky.dev/state-machine-native",
+  "name": "@dunky.dev/native-state-machine",
   "version": "0.2.0",
   "license": "MIT",
   "repository": {
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@dunky.dev/state-machine": "workspace:^",
-    "@dunky.dev/state-machine-react": "workspace:^",
+    "@dunky.dev/react-state-machine": "workspace:^",
     "@dunky.dev/state-machine-utils": "workspace:^"
   },
   "peerDependencies": {

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -33,8 +33,8 @@
     "build": "tsdown"
   },
   "dependencies": {
-    "@dunky.dev/state-machine": "workspace:^",
     "@dunky.dev/react-state-machine": "workspace:^",
+    "@dunky.dev/state-machine": "workspace:^",
     "@dunky.dev/state-machine-utils": "workspace:^"
   },
   "peerDependencies": {

--- a/packages/native/src/index.ts
+++ b/packages/native/src/index.ts
@@ -8,7 +8,7 @@ export {
   useSelector,
   type ComponentEffect,
   type ComponentEffects,
-} from '@dunky.dev/state-machine-react'
+} from '@dunky.dev/react-state-machine'
 
 export { normalize, type Bindings } from './normalize'
 // RN-aware mergeProps (handler compose + style array) layered on the

--- a/packages/native/tests/merge-props.test.ts
+++ b/packages/native/tests/merge-props.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { mergeProps } from '@dunky.dev/state-machine-native'
+import { mergeProps } from '@dunky.dev/native-state-machine'
 
 describe('mergeProps', () => {
   it('inherits handler composition from the agnostic base', () => {

--- a/packages/native/tests/normalize.test.ts
+++ b/packages/native/tests/normalize.test.ts
@@ -11,7 +11,7 @@
  *     accessibilityLabelledBy, id → nativeID.
  */
 import { describe, expect, it, vi } from 'vitest'
-import { normalize } from '@dunky.dev/state-machine-native'
+import { normalize } from '@dunky.dev/native-state-machine'
 
 describe('native normalize — handlers', () => {
   it('keeps onPress as-is (RN Pressable.onPress)', () => {

--- a/packages/opentui/package.json
+++ b/packages/opentui/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@dunky.dev/state-machine-opentui",
+  "name": "@dunky.dev/opentui-state-machine",
   "version": "0.2.0",
   "license": "MIT",
   "repository": {

--- a/packages/opentui/src/index.ts
+++ b/packages/opentui/src/index.ts
@@ -1,5 +1,5 @@
 // =============================================================================
-// @dunky.dev/state-machine-opentui
+// @dunky.dev/opentui-state-machine
 //
 // The OpenTUI (terminal) binding TARGET: the substrate-specific translation of
 // the agnostic binding vocabulary into OpenTUI renderable props. Pure functions

--- a/packages/opentui/tests/merge-props.test.ts
+++ b/packages/opentui/tests/merge-props.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { mergeProps } from '@dunky.dev/state-machine-opentui'
+import { mergeProps } from '@dunky.dev/opentui-state-machine'
 
 describe('mergeProps', () => {
   it('inherits handler composition from the agnostic base', () => {

--- a/packages/opentui/tests/normalize.test.ts
+++ b/packages/opentui/tests/normalize.test.ts
@@ -15,7 +15,7 @@
  *   - hidden → visible (inverted), focusable → focusable, disabled passes through.
  */
 import { describe, expect, it, vi } from 'vitest'
-import { normalize } from '@dunky.dev/state-machine-opentui'
+import { normalize } from '@dunky.dev/opentui-state-machine'
 
 describe('opentui normalize — handlers', () => {
   it('maps onPress to onMouseDown (no synthetic click in a terminal)', () => {

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,4 +1,4 @@
-# `@dunky.dev/state-machine-react`
+# `@dunky.dev/react-state-machine`
 
 The **React bindings** for [`@dunky.dev/state-machine`](../core/README.md).
 The core engine is renderer-agnostic; this package is the thin React edge that
@@ -74,7 +74,7 @@ the generated `useApi` owns the `useEffect`s:
 
 ```ts
 // a target component's effects.ts (illustrative — components live outside this repo)
-import type { ComponentEffect } from '@dunky.dev/state-machine-react'
+import type { ComponentEffect } from '@dunky.dev/react-state-machine'
 
 type TooltipEffect = ComponentEffect<TooltipMachine, TooltipMachineProps>
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@dunky.dev/state-machine-react",
+  "name": "@dunky.dev/react-state-machine",
   "version": "0.2.0",
   "license": "MIT",
   "repository": {

--- a/packages/react/tests/merge-props.test.ts
+++ b/packages/react/tests/merge-props.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { mergeProps } from '@dunky.dev/state-machine-react'
+import { mergeProps } from '@dunky.dev/react-state-machine'
 
 describe('mergeProps', () => {
   it('inherits handler composition from the agnostic base', () => {

--- a/packages/react/tests/normalize.test.ts
+++ b/packages/react/tests/normalize.test.ts
@@ -8,7 +8,7 @@
  * pass-through.
  */
 import { describe, expect, it, vi } from 'vitest'
-import { normalize } from '@dunky.dev/state-machine-react'
+import { normalize } from '@dunky.dev/react-state-machine'
 
 describe('react normalize — handlers', () => {
   it('maps onPress to onClick (the DOM activation event)', () => {

--- a/packages/react/tests/use-machine.test.tsx
+++ b/packages/react/tests/use-machine.test.tsx
@@ -17,7 +17,7 @@ import {
   type Connect,
   type TransitionConfig,
 } from '@dunky.dev/state-machine'
-import { type ComponentEffects, useMachine } from '@dunky.dev/state-machine-react'
+import { type ComponentEffects, useMachine } from '@dunky.dev/react-state-machine'
 
 type ToggleState = 'closed' | 'open'
 interface ToggleCtx {

--- a/packages/react/tests/use-selector.test.tsx
+++ b/packages/react/tests/use-selector.test.tsx
@@ -10,7 +10,7 @@
 import { act, render } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { act as write, machine, type TransitionConfig } from '@dunky.dev/state-machine'
-import { useSelector } from '@dunky.dev/state-machine-react'
+import { useSelector } from '@dunky.dev/react-state-machine'
 
 type S = 'idle'
 interface Ctx {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,12 +47,12 @@ importers:
 
   benchmark:
     dependencies:
+      '@dunky.dev/react-state-machine':
+        specifier: workspace:^
+        version: link:../packages/react
       '@dunky.dev/state-machine':
         specifier: workspace:^
         version: link:../packages/core
-      '@dunky.dev/state-machine-react':
-        specifier: workspace:^
-        version: link:../packages/react
     devDependencies:
       '@types/jsdom':
         specifier: ^21.1.7
@@ -126,12 +126,12 @@ importers:
 
   packages/native:
     dependencies:
+      '@dunky.dev/react-state-machine':
+        specifier: workspace:^
+        version: link:../react
       '@dunky.dev/state-machine':
         specifier: workspace:^
         version: link:../core
-      '@dunky.dev/state-machine-react':
-        specifier: workspace:^
-        version: link:../react
       '@dunky.dev/state-machine-utils':
         specifier: workspace:^
         version: link:../shared/utils
@@ -182,18 +182,18 @@ importers:
 
   sandbox/native:
     dependencies:
+      '@dunky.dev/native-state-machine':
+        specifier: workspace:^
+        version: link:../../packages/native
+      '@dunky.dev/react-state-machine':
+        specifier: workspace:^
+        version: link:../../packages/react
       '@dunky.dev/state-machine':
         specifier: workspace:^
         version: link:../../packages/core
       '@dunky.dev/state-machine-bindings':
         specifier: workspace:^
         version: link:../../packages/shared/bindings
-      '@dunky.dev/state-machine-native':
-        specifier: workspace:^
-        version: link:../../packages/native
-      '@dunky.dev/state-machine-react':
-        specifier: workspace:^
-        version: link:../../packages/react
       '@dunky.dev/state-machine-utils':
         specifier: workspace:^
         version: link:../../packages/shared/utils
@@ -222,18 +222,18 @@ importers:
 
   sandbox/opentui:
     dependencies:
+      '@dunky.dev/opentui-state-machine':
+        specifier: workspace:^
+        version: link:../../packages/opentui
+      '@dunky.dev/react-state-machine':
+        specifier: workspace:^
+        version: link:../../packages/react
       '@dunky.dev/state-machine':
         specifier: workspace:^
         version: link:../../packages/core
       '@dunky.dev/state-machine-bindings':
         specifier: workspace:^
         version: link:../../packages/shared/bindings
-      '@dunky.dev/state-machine-opentui':
-        specifier: workspace:^
-        version: link:../../packages/opentui
-      '@dunky.dev/state-machine-react':
-        specifier: workspace:^
-        version: link:../../packages/react
       '@dunky.dev/state-machine-utils':
         specifier: workspace:^
         version: link:../../packages/shared/utils
@@ -259,15 +259,15 @@ importers:
 
   sandbox/react:
     dependencies:
+      '@dunky.dev/react-state-machine':
+        specifier: workspace:^
+        version: link:../../packages/react
       '@dunky.dev/state-machine':
         specifier: workspace:^
         version: link:../../packages/core
       '@dunky.dev/state-machine-bindings':
         specifier: workspace:^
         version: link:../../packages/shared/bindings
-      '@dunky.dev/state-machine-react':
-        specifier: workspace:^
-        version: link:../../packages/react
       '@dunky.dev/state-machine-utils':
         specifier: workspace:^
         version: link:../../packages/shared/utils
@@ -1531,89 +1531,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1753,6 +1769,7 @@ packages:
     resolution: {integrity: sha512-Eps9qB+vQ/Lel4ZYqMH87Um9oiU17Vu4oWzvRi40Yf+69vA1a3R4D7KUCeY3OxKWnRnwAHkMU9TxNnjKngPH/w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@opentui/core-linux-arm64@0.4.1':
     resolution: {integrity: sha512-sBZTS1eEGeVSQ8fAmDALKQcT7FckrhK64oHfEO7W0lJ+lXapfJuOKtTM33na54V56GAM9guk4RD4cbPeTXEh4g==}
@@ -1763,6 +1780,7 @@ packages:
     resolution: {integrity: sha512-UYcp8XGX4DZXN+VYUVuCrJkbFMJ0L+VUVu0t5KqqaeJ74fI4NZ+DmwNqPPg1+C+EIzoW4QChlEUdhlZRdiEQiA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@opentui/core-linux-x64@0.4.1':
     resolution: {integrity: sha512-9/xjYGzX5RdUl0qmGQY0OCayjJ4VffDhsBmApQdseUkMT6LGL3RumI4zPK3Y9vo1fuy6ffLnriLFOktOgutXDg==}
@@ -1841,48 +1859,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.133.0':
     resolution: {integrity: sha512-wJQGamIosQBoJHW9+S5XxrtKRo3eyJxsnS1XCPrqN0LHi8uw1pTqqTfn3t/NVuvbBg7Pumn4ez9Eidgcn0xbEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.133.0':
     resolution: {integrity: sha512-Koaz32/O5+abIfrNGdyndgRvdOZ9jEf5/z3Ep9h3h2QWpdDiUQpVwgH0OcMXCs+l9aXxPLtkupqyVig9W6FDKw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.133.0':
     resolution: {integrity: sha512-R4vOjWzxhnNWHnVLeiB6jNuIifdy9vcMXZGPc7StXcxBovI+U2zg1QhZ9o8OjV80oGivs1lX5NfPLzk4IPqlRA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-musl@0.133.0':
     resolution: {integrity: sha512-iwgBNUTHiMdxARLYuM0SBlnYeb19iw1Ea5M+4ERZupCsBMLArti6FyZ6UfFjJxIiTDr2oW2DGQFxlQVQ/dW9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.133.0':
     resolution: {integrity: sha512-ZwZNo8FZmB/gVfboQl+wXilBigGl+6nQQs+nITOeAP/HcAOjiHl6XZJL9F/KXNEspODQcbjAiyjUbeCJd9a0fA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.133.0':
     resolution: {integrity: sha512-govCvWx1dBlED3uu4qXctxpRcouu9I8Kn+DBktGCl760JtlGJzc9l/OmPJKlYWSbrRqKkMZehNeZ/4Wfma7uSA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.133.0':
     resolution: {integrity: sha512-ssTlpXD5Mq9uCssDJPzlRWqBt4Y7Zzd9i+XZhWmK/9Y6KUIuAxVYTYiI8lxcGWi0+3/Cz4A8q9UrD4NK9Y2j7g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-openharmony-arm64@0.133.0':
     resolution: {integrity: sha512-51aByfXhPtLEdWG4a2Ihdw6cPWV1ei1AarALpFdDP8MLWDLE2NuUMgbo3DERR2Kt8fT/ok1GUvBiLxVGke9uUQ==}
@@ -1961,41 +1987,49 @@ packages:
     resolution: {integrity: sha512-0bJnmYFp62JdZ4nVMDUZ/C58BCZOCcqgKtnUlp7L9Ojf/czIN+3j72YlLPeWLkzlr6SlYvIQA4SGV/HyO0d+qg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.20.0':
     resolution: {integrity: sha512-wKHHzPKZo7Ufhv/Bt6yxT7FOgnIgW4gwXcJUipkShGp68W3wGVqvr1Sr0fY65lN0Oy6y41+g2kIDvkgZaMMUkw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.20.0':
     resolution: {integrity: sha512-RN8goF7Ie0B79L4i4G6OeBocTgSC56vJbQ65VJje+oXnldVpLnOU7j/AQ/dP94TcCS+Yh6WG8u3Qt4ETteXFNQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.20.0':
     resolution: {integrity: sha512-5l1yU6/xQEqLZRzxqmMxJfWPslpwCmBsdDGaBvABPehxquCXDC7dd7oraNdKSJUMDXSM7VvVj8H2D2FTjU7oWw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.20.0':
     resolution: {integrity: sha512-xHEvkbgz6UC+A3JOyDQy76LkUaxsNSfIr3/GV8slwZsnuooJiIB34gzJfsyvR4JdCYNUUPsRJc/w/oWkODu+hg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.20.0':
     resolution: {integrity: sha512-aWPDUUmSeyHvlW+SoEUd+JIJsQhVhu6a5tBpDRMu058naPAchTgAVGCFy35zjbnFlt0i8hLWziff6HX0D3LU4g==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.20.0':
     resolution: {integrity: sha512-x2YeSimvhJjKLVD8KSu8f/rqU1potcdEMkApIPJqjZWN7c2Fpt4g2X32WDg1p+XDAmyT7nuQGe0vnhvXeLbH+g==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.20.0':
     resolution: {integrity: sha512-kcRLEIxpZefeYfLChjpgFf3ilBzRDZ+yobMrpRsQlSrxuFGtm3U6PMU7AaEpMqo3NfDGVyJJseAjnRLzMFHjwQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.20.0':
     resolution: {integrity: sha512-HHcfnApSZGtKhTiHqe8OZruOZe5XuFQH5/E0Yhj3u8fnFvzkM4/k6WjacUf4SvA0SPEAbfbgYmVPuo0VX/fIBQ==}
@@ -2064,48 +2098,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-arm64-musl@0.52.0':
     resolution: {integrity: sha512-wZg6bLjDvh2KibyI3QFUYo8GTXneIFsd0JvehtvJiUmQ8WRPERgxd/VM4ctWb86U5FT1FkqgS8/wZKVB+AZScg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-linux-ppc64-gnu@0.52.0':
     resolution: {integrity: sha512-IngE8uxhNvxcMrLjZNDo9xNLY7rEK33AKnaMd2B46he1e/mz2CfcW6If/U1wUjdRZddm1QzQaciqZkuMkdh1FA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-gnu@0.52.0':
     resolution: {integrity: sha512-H3+DdFMv/efN3Efmhsv18jDrpiWWqKG7wsfAlQBqAt6z/E2Bx+TwEj2Nowe51CPOWB8/mFBC2dAMSgVFLvvowA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-musl@0.52.0':
     resolution: {integrity: sha512-zji+1kb7lJKohSDjzC1IsS+K/cKRs1hdVf0ZH0VbdbiakmtLvN9twBoXo/k8VdjFax7kfo+DyPxS7vv52br1aw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-linux-s390x-gnu@0.52.0':
     resolution: {integrity: sha512-hcLBYedpCy7ToUvvBidWk7+11Yhg1oAZ4+6hKPic/mQI6NaqXJSXMps5nFlwUuX2ewhtLZZDPg63TI042qGKBg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-gnu@0.52.0':
     resolution: {integrity: sha512-IDO2loXK2OtTOhSPchU9MW25mWL2QCDGdJbjN8MXKZVS80qXe5gMTwQWu/gMJ3juoBHbkuUZNB2N1LHzNT7DoA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-musl@0.52.0':
     resolution: {integrity: sha512-mAV2Hjn0SatJ+KoAzKUC3eJhdJ8wv+3m1KyuS0dTsbF0c5weq+QrCt/DRZZM+uj/XiKzCDEUKYsBF30e2qkcyw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-openharmony-arm64@0.52.0':
     resolution: {integrity: sha512-vd4npaUIwChxp7XzkqmepBWTT9YMcSe/NBApVGPC30/lLyOVaV3dvma1SKo03t8O73BPRAG7EyJzGlN5cJM5hQ==}
@@ -2178,48 +2220,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-musl@1.67.0':
     resolution: {integrity: sha512-zB/Tf6sUjmmvvbva9Gj3JTJ8rJ9t4I8/U0o6vSRtd0DRIsIuyegBwJAzhSUFQHdMijIRJkW0exs/yBhpw2S20w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-ppc64-gnu@1.67.0':
     resolution: {integrity: sha512-kgU40Gt74CK0TCsF51KZymkIwN9U0BajKsMijB52zPqOeZU9NAHkA/NSQkZDHEaCakx42DxhXkODiAqf2b4Gug==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-gnu@1.67.0':
     resolution: {integrity: sha512-tOYhkk/iaG9aD3FvGpBFd1Lrw0x0RaVoJBxjUkfNzS50rC5NS5BteNCwgr8A2zCdADrIIoze6D7u6U5Ic++/iQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-musl@1.67.0':
     resolution: {integrity: sha512-sEtywrPb+0b+tHYl1SDCrw903fiC4eyKoNqzP3v+f2JT3Xcv4NEYG+P8rj+eEnX7IWhqV/xj8/JmcmVj21CXaA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-s390x-gnu@1.67.0':
     resolution: {integrity: sha512-BvR8Moa0zCLxroOx4vZaZN9nUfwAUpSTwjZdxZyKy4bv3PrzrXrxKR/ZQ0L9wNSvlPhnMJeZfa3q5w6ZCTuN6Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-gnu@1.67.0':
     resolution: {integrity: sha512-mm2cxM6fksOpq6l0uFws8BUGKAR4dNa/cZCn37Npq7PFbhD5HDJqWfnoIvTaeRKMy5XdS2tO0MA0qbHDrnXAAA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.67.0':
     resolution: {integrity: sha512-WmbMuLapKyDlobMkXAaAL0Y+Uczh4LETfIfQsUpbId4Ip8Ai82/jqeYTOoUCkuuhBFapgqP253+d83tLKOksJg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-openharmony-arm64@1.67.0':
     resolution: {integrity: sha512-9g/PqxYJelzzTAOR5Y+RiRqdeydhEuXv2KxNeFcAKQ7UsvnWSY1OP4MsuPMbTO2Pf70tz7mFhl1j13H3fyh+8g==}
@@ -2490,72 +2540,84 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.1.1':
     resolution: {integrity: sha512-at2EO4o7D/PJLC4Xik16bU4CcjQE2tSv1LfqMA0TRYQYQihRm3gZeDB8xaX28A9SFedibcAk5DeMCKt4REKG0A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.2':
     resolution: {integrity: sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.1.1':
     resolution: {integrity: sha512-5PUjZx366h9tkJTPJF5eibxOlK3sGoeRiBJLLjjEB5/kLDuhr6qB3LkhqLz1smXNgsX+pBhnbcJBrPE30HznAA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.2':
     resolution: {integrity: sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-ppc64-gnu@1.1.1':
     resolution: {integrity: sha512-1WK84XPeio3tjP1sM/TMXiC0G1i1iq1qGZ71KfNQjEFLU1kwD+Cv5T8nGySg/JUFwLbaScu6ve9DmeXlmqpkFA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.2':
     resolution: {integrity: sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.1.1':
     resolution: {integrity: sha512-1nS1X5z1uMJ369RU25hTpKCFvUwXZp12dIzlzk4S+UxCTcSVGsAE6tzkOSufv/7jnmAtK0ZlrsJxh2fGmsnVSw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.2':
     resolution: {integrity: sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.1.1':
     resolution: {integrity: sha512-NwX/wspnq4vYyMFsqbYvzums3ki/Tk8FZbMzMAovPDp3OfLeYKby/D+9osokadXuYEV3OvpeHlwnr/bG8QMixA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.2':
     resolution: {integrity: sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.1.1':
     resolution: {integrity: sha512-+n46LhDrJFQM+229y4oXtVpj1G50U/+XuHMlpnisFTEXhrg9f/YIjp/HymX+PVJjBEr7XHRs3CFLelV464pqwA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.2':
     resolution: {integrity: sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==}
@@ -2649,66 +2711,79 @@ packages:
     resolution: {integrity: sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.0':
     resolution: {integrity: sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.0':
     resolution: {integrity: sha512-bVURMg+6eNN9C/yc0aVjooZcwTTtYF4YW3xta5pP0//r3o1V8gXEHXWCndj47w/HhwsFroZrFhR+6uQP5T0n0g==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.0':
     resolution: {integrity: sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.0':
     resolution: {integrity: sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.0':
     resolution: {integrity: sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.0':
     resolution: {integrity: sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.0':
     resolution: {integrity: sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.0':
     resolution: {integrity: sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.0':
     resolution: {integrity: sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.0':
     resolution: {integrity: sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.0':
     resolution: {integrity: sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.0':
     resolution: {integrity: sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.0':
     resolution: {integrity: sha512-3oVS7FLGa4U1qcvao9ylGxrjXZyUQqR8UwxEcnUEyPX53O/C/mKDZegNXTdHCP+h3e6ta/f1EN38Yif1mmZHYg==}
@@ -2821,24 +2896,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.1':
     resolution: {integrity: sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.1':
     resolution: {integrity: sha512-Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.1':
     resolution: {integrity: sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.1':
     resolution: {integrity: sha512-zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA==}
@@ -4605,24 +4684,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -8482,6 +8565,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.2
+    optional: true
+
   '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)':
     dependencies:
       '@emnapi/core': 1.11.0
@@ -8680,7 +8770,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@oxc-resolver/binding-win32-arm64-msvc@11.20.0':
@@ -9129,7 +9219,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.1.1':

--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -16,10 +16,10 @@ sandbox/
 ```
 
 The split that makes this work: the lifecycle hook (`useMachine`) comes from
-`@dunky.dev/state-machine-react` — all three targets render through a React
+`@dunky.dev/react-state-machine` — all three targets render through a React
 reconciler — while the **prop translator** (`normalize`) comes from each target's
 own package. The OpenTUI app is the clearest proof: it imports `useMachine` from
-the React binding and `normalize` from `@dunky.dev/state-machine-opentui`, exactly
+the React binding and `normalize` from `@dunky.dev/opentui-state-machine`, exactly
 the "bring your own framework hook, pair it with the agnostic translator" model.
 
 ## Run

--- a/sandbox/native/command-palette.tsx
+++ b/sandbox/native/command-palette.tsx
@@ -2,8 +2,8 @@ import { useEffect, useRef } from 'react'
 import { Modal, Pressable, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native'
 // Same split as the OpenTUI app: lifecycle hook from the React binding (RN uses a
 // React renderer), prop translator from the native package.
-import { useMachine } from '@dunky.dev/state-machine-react'
-import { mergeProps, normalize } from '@dunky.dev/state-machine-native'
+import { useMachine } from '@dunky.dev/react-state-machine'
+import { mergeProps, normalize } from '@dunky.dev/native-state-machine'
 import {
   commandPaletteMachineConfig,
   type CommandPaletteProps,

--- a/sandbox/native/package.json
+++ b/sandbox/native/package.json
@@ -9,10 +9,10 @@
     "android": "expo run:android"
   },
   "dependencies": {
-    "@dunky.dev/state-machine": "workspace:^",
-    "@dunky.dev/state-machine-bindings": "workspace:^",
     "@dunky.dev/native-state-machine": "workspace:^",
     "@dunky.dev/react-state-machine": "workspace:^",
+    "@dunky.dev/state-machine": "workspace:^",
+    "@dunky.dev/state-machine-bindings": "workspace:^",
     "@dunky.dev/state-machine-utils": "workspace:^",
     "@sandbox/cmdk-core": "workspace:^",
     "expo": "^54.0.0",

--- a/sandbox/native/package.json
+++ b/sandbox/native/package.json
@@ -11,8 +11,8 @@
   "dependencies": {
     "@dunky.dev/state-machine": "workspace:^",
     "@dunky.dev/state-machine-bindings": "workspace:^",
-    "@dunky.dev/state-machine-native": "workspace:^",
-    "@dunky.dev/state-machine-react": "workspace:^",
+    "@dunky.dev/native-state-machine": "workspace:^",
+    "@dunky.dev/react-state-machine": "workspace:^",
     "@dunky.dev/state-machine-utils": "workspace:^",
     "@sandbox/cmdk-core": "workspace:^",
     "expo": "^54.0.0",

--- a/sandbox/opentui/package.json
+++ b/sandbox/opentui/package.json
@@ -9,8 +9,8 @@
   "dependencies": {
     "@dunky.dev/state-machine": "workspace:^",
     "@dunky.dev/state-machine-bindings": "workspace:^",
-    "@dunky.dev/state-machine-opentui": "workspace:^",
-    "@dunky.dev/state-machine-react": "workspace:^",
+    "@dunky.dev/opentui-state-machine": "workspace:^",
+    "@dunky.dev/react-state-machine": "workspace:^",
     "@dunky.dev/state-machine-utils": "workspace:^",
     "@opentui/core": "^0.4.1",
     "@opentui/react": "^0.4.1",

--- a/sandbox/opentui/package.json
+++ b/sandbox/opentui/package.json
@@ -7,10 +7,10 @@
     "dev": "bun run src/index.tsx"
   },
   "dependencies": {
-    "@dunky.dev/state-machine": "workspace:^",
-    "@dunky.dev/state-machine-bindings": "workspace:^",
     "@dunky.dev/opentui-state-machine": "workspace:^",
     "@dunky.dev/react-state-machine": "workspace:^",
+    "@dunky.dev/state-machine": "workspace:^",
+    "@dunky.dev/state-machine-bindings": "workspace:^",
     "@dunky.dev/state-machine-utils": "workspace:^",
     "@opentui/core": "^0.4.1",
     "@opentui/react": "^0.4.1",

--- a/sandbox/opentui/src/command-palette.tsx
+++ b/sandbox/opentui/src/command-palette.tsx
@@ -3,8 +3,8 @@ import { useKeyboard } from '@opentui/react'
 // The lifecycle hook comes from the React binding (OpenTUI renders via a React
 // reconciler), exactly as the opentui package's docs prescribe: bring your own
 // framework hook, pair it with this `normalize`.
-import { useMachine } from '@dunky.dev/state-machine-react'
-import { normalize } from '@dunky.dev/state-machine-opentui'
+import { useMachine } from '@dunky.dev/react-state-machine'
+import { normalize } from '@dunky.dev/opentui-state-machine'
 import {
   commandPaletteMachineConfig,
   type CommandPaletteProps,

--- a/sandbox/react/package.json
+++ b/sandbox/react/package.json
@@ -9,9 +9,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@dunky.dev/react-state-machine": "workspace:^",
     "@dunky.dev/state-machine": "workspace:^",
     "@dunky.dev/state-machine-bindings": "workspace:^",
-    "@dunky.dev/react-state-machine": "workspace:^",
     "@dunky.dev/state-machine-utils": "workspace:^",
     "@sandbox/cmdk-core": "workspace:^",
     "react": "^19.2.6",

--- a/sandbox/react/package.json
+++ b/sandbox/react/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@dunky.dev/state-machine": "workspace:^",
     "@dunky.dev/state-machine-bindings": "workspace:^",
-    "@dunky.dev/state-machine-react": "workspace:^",
+    "@dunky.dev/react-state-machine": "workspace:^",
     "@dunky.dev/state-machine-utils": "workspace:^",
     "@sandbox/cmdk-core": "workspace:^",
     "react": "^19.2.6",

--- a/sandbox/react/src/command-palette.tsx
+++ b/sandbox/react/src/command-palette.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react'
-import { type ComponentEffect, normalize, useMachine } from '@dunky.dev/state-machine-react'
+import { type ComponentEffect, normalize, useMachine } from '@dunky.dev/react-state-machine'
 import {
   commandPaletteMachineConfig,
   type CommandPaletteMachine,

--- a/sandbox/react/vite.config.ts
+++ b/sandbox/react/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@dunky.dev/state-machine': resolve(__dirname, '../../packages/core/src'),
-      '@dunky.dev/state-machine-react': resolve(__dirname, '../../packages/react/src'),
+      '@dunky.dev/react-state-machine': resolve(__dirname, '../../packages/react/src'),
       '@dunky.dev/state-machine-utils': resolve(__dirname, '../../packages/shared/utils/src'),
       '@dunky.dev/state-machine-bindings': resolve(__dirname, '../../packages/shared/bindings/src'),
       '@sandbox/cmdk-core': resolve(__dirname, '../shared/src'),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,9 +15,9 @@
     "strict": true,
     "paths": {
       "@dunky.dev/state-machine": ["./packages/core/src"],
-      "@dunky.dev/state-machine-react": ["./packages/react/src"],
-      "@dunky.dev/state-machine-native": ["./packages/native/src"],
-      "@dunky.dev/state-machine-opentui": ["./packages/opentui/src"],
+      "@dunky.dev/react-state-machine": ["./packages/react/src"],
+      "@dunky.dev/native-state-machine": ["./packages/native/src"],
+      "@dunky.dev/opentui-state-machine": ["./packages/opentui/src"],
       "@dunky.dev/state-machine-utils": ["./packages/shared/utils/src"],
       "@dunky.dev/state-machine-bindings": ["./packages/shared/bindings/src"]
     },

--- a/website/src/content/docs/api/effects.mdx
+++ b/website/src/content/docs/api/effects.mdx
@@ -48,7 +48,7 @@ effects: [
 **`ComponentEffect`:** needs the DOM or reads a prop. Declared outside the machine, passed to `useMachine` in your React component. A `ComponentEffect` is a `[fn, deps]` tuple: the function gets the running machine and current props, and `deps` names the props it reads so the bridge re-runs it only when those change:
 
 ```ts
-import { type ComponentEffect } from '@dunky.dev/state-machine-react'
+import { type ComponentEffect } from '@dunky.dev/react-state-machine'
 import type { DisclosureMachine, DisclosureProps } from './machine'
 
 // can't live in the machine: touches the DOM and reads a prop
@@ -71,7 +71,7 @@ export const disclosureEffects = [onEscapeKey]
 Then pass it to `useMachine` in your component:
 
 ```tsx
-import { useMachine, normalize } from '@dunky.dev/state-machine-react'
+import { useMachine, normalize } from '@dunky.dev/react-state-machine'
 import { createDisclosureConfig, connectDisclosure } from './machine'
 import { disclosureEffects } from './effects'
 

--- a/website/src/content/docs/get-started.mdx
+++ b/website/src/content/docs/get-started.mdx
@@ -52,7 +52,7 @@ Dunky splits the problem into three independent layers:
 | ------------ | ---------------------------------------------- | ----------------------- |
 | **Behavior** | `@dunky.dev/state-machine`                     | _What_ a component does |
 | **Styles**   | `@dunky.dev/style-engine`                      | _How_ it looks          |
-| **Render**   | `@dunky.dev/state-machine-react` (and friends) | _Where_ it renders      |
+| **Render**   | `@dunky.dev/react-state-machine` (and friends) | _Where_ it renders      |
 
 You're here for layer one.
 

--- a/website/src/content/docs/libs/opentui.mdx
+++ b/website/src/content/docs/libs/opentui.mdx
@@ -5,7 +5,7 @@ description: OpenTUI (terminal) bindings for @dunky.dev/state-machine.
 
 import Install from '../../../components/install.astro'
 
-<Install pkg='@dunky.dev/state-machine-opentui' />
+<Install pkg='@dunky.dev/opentui-state-machine' />
 
 The OpenTUI package is **only the prop translator**. Unlike [React](/libs/react) and [React Native](/libs/react-native), it ships no `useMachine` hook and has no framework dependency — `normalize` and `mergeProps` are pure object-to-object functions, so they work the same under any of OpenTUI's reactive bindings (`@opentui/react`, `@opentui/solid`, …). **The machine itself is unchanged.** The same `createDialogConfig` and `connectDialog` that drive the DOM run the terminal.
 
@@ -14,8 +14,8 @@ The OpenTUI package is **only the prop translator**. Unlike [React](/libs/react)
 The lifecycle binding — turning the engine's connector into a live component — is the consuming app's concern. OpenTUI renders through a React reconciler, so the standard pairing is `useMachine` from the **React** package plus `normalize` from **this** package:
 
 ```tsx
-import { useMachine } from '@dunky.dev/state-machine-react'
-import { normalize } from '@dunky.dev/state-machine-opentui'
+import { useMachine } from '@dunky.dev/react-state-machine'
+import { normalize } from '@dunky.dev/opentui-state-machine'
 import { createDialogConfig, connectDialog } from './dialog'
 
 function Dialog(props: DialogProps) {

--- a/website/src/content/docs/libs/react-native.mdx
+++ b/website/src/content/docs/libs/react-native.mdx
@@ -5,16 +5,16 @@ description: React Native bindings for @dunky.dev/state-machine.
 
 import Install from '../../../components/install.astro'
 
-<Install pkg='@dunky.dev/state-machine-native' />
+<Install pkg='@dunky.dev/native-state-machine' />
 
 The React Native package is the same thin edge layer as React (same lifecycle hook, same `ComponentEffect` model) with one difference: `normalize` translates bindings to React Native props instead of DOM/ARIA props. **The machine itself is unchanged.** The same config and `connect` function run on both platforms.
 
 ## `useMachine`, `useSelector`, `ComponentEffect`
 
-Re-exported directly from `@dunky.dev/state-machine-react`, identical on both platforms because React Native uses the same React renderer. See the [React](/libs/react) page for full docs on these.
+Re-exported directly from `@dunky.dev/react-state-machine`, identical on both platforms because React Native uses the same React renderer. See the [React](/libs/react) page for full docs on these.
 
 ```tsx
-import { useMachine, useSelector, type ComponentEffect } from '@dunky.dev/state-machine-native'
+import { useMachine, useSelector, type ComponentEffect } from '@dunky.dev/native-state-machine'
 ```
 
 ## `normalize`: bindings → React Native props
@@ -22,7 +22,7 @@ import { useMachine, useSelector, type ComponentEffect } from '@dunky.dev/state-
 The RN `normalize` translates the same agnostic bindings to React Native's prop vocabulary:
 
 ```tsx
-import { normalize } from '@dunky.dev/state-machine-native'
+import { normalize } from '@dunky.dev/native-state-machine'
 ;<Pressable {...normalize(api.triggerProps)} />
 ```
 
@@ -46,7 +46,7 @@ Bindings with no RN equivalent are silently dropped rather than passed as invali
 RN-aware merge: handlers are chained, `style` is merged as a `[consumerStyle, libraryStyle]` array (RN accepts style arrays natively), everything else the component wins.
 
 ```tsx
-import { mergeProps, normalize } from '@dunky.dev/state-machine-native'
+import { mergeProps, normalize } from '@dunky.dev/native-state-machine'
 ;<Pressable {...mergeProps(props, normalize(api.triggerProps))} />
 ```
 
@@ -56,7 +56,7 @@ Platform effects work the same way: a `[setup/teardown, depPropNames]` tuple pas
 
 ```ts
 import { BackHandler } from 'react-native'
-import type { ComponentEffect } from '@dunky.dev/state-machine-native'
+import type { ComponentEffect } from '@dunky.dev/native-state-machine'
 import type { DialogMachine, DialogProps } from './machine'
 
 type Effect = ComponentEffect<DialogMachine, DialogProps>
@@ -90,12 +90,12 @@ export const connectDisclosure = ({ state, send }) => ({ ... })
 
 ```tsx
 // web: Disclosure.tsx
-import { useMachine, normalize } from '@dunky.dev/state-machine-react'
+import { useMachine, normalize } from '@dunky.dev/react-state-machine'
 import { createDisclosureConfig, connectDisclosure } from '../shared/disclosure'
 import { disclosureEffects } from './effects' // DOM keydown listener
 
 // native: Disclosure.native.tsx
-import { useMachine, normalize } from '@dunky.dev/state-machine-native'
+import { useMachine, normalize } from '@dunky.dev/native-state-machine'
 import { createDisclosureConfig, connectDisclosure } from '../shared/disclosure'
 import { disclosureEffects } from './effects' // BackHandler
 ```

--- a/website/src/content/docs/libs/react.mdx
+++ b/website/src/content/docs/libs/react.mdx
@@ -5,7 +5,7 @@ description: React bindings for @dunky.dev/state-machine.
 
 import Install from '../../../components/install.astro'
 
-<Install pkg='@dunky.dev/state-machine-react' />
+<Install pkg='@dunky.dev/react-state-machine' />
 
 The React package is a thin edge layer. Behavior lives in the core machine and the component's `connect` function; this package only adapts them to React: lifecycle, rendering, prop translation, and platform effects.
 
@@ -14,7 +14,7 @@ The React package is a thin edge layer. Behavior lives in the core machine and t
 The one bridge hook. Every component calls it with the four agnostic pieces and gets back the view API:
 
 ```tsx
-import { useMachine, normalize } from '@dunky.dev/state-machine-react'
+import { useMachine, normalize } from '@dunky.dev/react-state-machine'
 import { createDialogConfig, connectDialog, dialogEffects } from './dialog'
 
 type DialogProps = {
@@ -125,7 +125,7 @@ When a consumer spreads their own props onto the same element the component cont
 For a leaf component that should only re-render when one slice of the machine changes (useful when a single machine drives many rows and each row should only wake for its own value):
 
 ```tsx
-import { useSelector } from '@dunky.dev/state-machine-react'
+import { useSelector } from '@dunky.dev/react-state-machine'
 
 function Row({ machine, value }) {
   const isHighlighted = useSelector(machine, () => machine.context.highlightedValue === value)
@@ -149,7 +149,7 @@ const pos = useSelector(
 Some behavior can't live in the machine because it touches the DOM or reads props the machine never sees. Declare each as a `[setup/teardown, depPropNames]` tuple; `useMachine` runs one `useEffect` per entry, keyed on its named prop deps:
 
 ```ts
-import type { ComponentEffect } from '@dunky.dev/state-machine-react'
+import type { ComponentEffect } from '@dunky.dev/react-state-machine'
 import type { DialogMachine, DialogProps } from './dialog'
 
 type Effect = ComponentEffect<DialogMachine, DialogProps>


### PR DESCRIPTION
## Summary

Renames the three framework-adapter packages from the `state-machine-*` suffix
convention to a `*-state-machine` substrate-prefix convention:

- `@dunky.dev/state-machine-react` → `@dunky.dev/react-state-machine`
- `@dunky.dev/state-machine-native` → `@dunky.dev/native-state-machine`
- `@dunky.dev/state-machine-opentui` → `@dunky.dev/opentui-state-machine`

`@dunky.dev/state-machine` (core), `@dunky.dev/state-machine-utils`, and
`@dunky.dev/state-machine-bindings` are unchanged — they aren't tied to one
substrate, so the substrate-prefix logic doesn't apply to them.

## Why

This reverses d0e20a5, which moved the adapters to the suffix form "so the
whole scope is consistent." That optimizes for browsing the `@dunky.dev/*`
scope as a maintainer — not for how a consumer actually finds and uses one
adapter.

Framework-first naming is the dominant convention for adapter packages in the
ecosystem — `react-redux`, `react-query`, `react-hook-form`, `react-dnd` all
put the framework first, not last. Prefix form:

- **Sorts with the rest of a consumer's framework-specific deps.** In a
  React project's `package.json`, `react-state-machine` lands next to
  `react-dom`, `react-router`, etc. `state-machine-react` sorts under "s",
  next to nothing related.
- **Groups under the org scope the way it should.** Browsing npm under
  `@dunky.dev/react-*` should surface every React package together. The
  suffix form breaks that — imagine a `button-react`, `dropdown-react`, and
  `state-machine-react` that never show up together anywhere, because
  "react" isn't what they're named by.
- **Reads correctly at the import site** — `import { useMachine } from
  '@dunky.dev/react-state-machine'` names the framework before the library,
  matching how the sentence would be said out loud.

See `.changeset/rename-adapters-to-prefix.md` for the full rationale.

## Scope

Renamed in package.json (`name` + `dependencies`), every import across
`packages/native`, `packages/opentui`, `packages/react` (src + tests),
`benchmark/`, `sandbox/`, `website/` docs, and both root/benchmark
`tsconfig.json` path maps. `pnpm-lock.yaml` regenerated. Historical
`CHANGELOG.md` entries are left untouched — they're a record of past
releases under the old name, not something to rewrite.

## Test plan
- [x] `pnpm test` — 307/307 passing
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm build` — all packages build, publint clean