### PR TITLE
fix(ci): unblock the changesets release PR

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -60,6 +60,8 @@ jobs:
       - run: pnpm format:check
 
   versioning:
+    # The release PR consumes changesets rather than adding one — never flag it.
+    if: github.head_ref != 'changeset-release/main'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# Changesets-generated; never hand-formatted, so never format-checked.
+**/CHANGELOG.md


### PR DESCRIPTION
## Summary

The "chore(release): version packages" PR (#45) has been permanently `BLOCKED` — not from a token/permissions issue, but from two CI checks that fail on every release PR by design:

- **`versioning`** runs `pnpm changeset status --since=origin/main` against the release PR itself. That check fails because the release PR's whole job is to *consume* the pending changesets (bump versions, update CHANGELOG.md, delete the `.md` files) — so it always looks like "packages changed, no changeset" from the check's point of view. Skipped this job specifically on the `changeset-release/main` branch.
- **`format`** runs `oxfmt --check` against the `CHANGELOG.md` files changesets itself generates, which never match `oxfmt`'s style since nothing hand-formats them. Added a `.prettierignore` excluding `**/CHANGELOG.md` — `oxfmt` reads `.prettierignore` automatically, no other config changes needed.

## Test plan
- [x] `pnpm format:check` — clean (182 files matched vs 190 before; the 8 `CHANGELOG.md` files are now excluded)
- [x] `pnpm test` — 307/307 passing
- [x] `pnpm lint` / `pnpm typecheck` — clean
- [ ] Once merged, PR #45 should go green and become mergeable