### PR TITLE
docs: add CONTRIBUTING.md, issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -17,7 +17,7 @@ run it, and see the bug with zero edits.
 
 ## Expected
 
-What you expected the machine to do.
+What you expected it to do.
 
 ## Actual
 
@@ -26,4 +26,3 @@ What it actually did.
 ## Version
 
 - `@dunky.dev/*` version:
-- Runtime (Node / Bun / browser) + version:

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Something doesn't behave the way the engine promises
+labels: bug
+---
+
+## SSCCE
+
+A **Short, Self-Contained, Correct (Compilable) Example** — the smallest
+`setup()`/`machine()` config that still reproduces the bug, with nothing to
+install or assume. Paste it as a single block; we should be able to copy it,
+run it, and see the bug with zero edits.
+
+```ts
+// paste your minimal repro here
+```
+
+## Expected
+
+What you expected the machine to do.
+
+## Actual
+
+What it actually did.
+
+## Version
+
+- `@dunky.dev/*` version:
+- Runtime (Node / Bun / browser) + version:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Question or discussion
+    url: https://github.com/dunky-dev/state-machine/discussions
+    about: Not a bug? Start a discussion instead.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+## What & why
+
+<!-- The change and the reason for it — not just what the diff does. -->
+
+## Checklist
+
+- [ ] Tests pass (`pnpm test`), lint is clean (`pnpm lint`), types check (`pnpm typecheck`)
+- [ ] Verified across every [scope](../AGENTS.md#scopes) the change touches
+- [ ] Changeset added (`pnpm changeset`) if this is a user-visible change to a public package

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,11 @@
-## What & why
+# Why/What
 
-<!-- The change and the reason for it — not just what the diff does. -->
+<!-- Why this change, and what it does — a sentence or two. -->
 
-## Checklist
+# Changes
 
-- [ ] Tests pass (`pnpm test`), lint is clean (`pnpm lint`), types check (`pnpm typecheck`)
-- [ ] Verified across every [scope](../AGENTS.md#scopes) the change touches
-- [ ] Changeset added (`pnpm changeset`) if this is a user-visible change to a public package
+<!-- The change itself, in a few words. -->
+
+# Issues
+
+<!-- Link related issues, e.g. Closes #123 -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,7 @@ the real cause yourself.
 
 ## Pull requests
 
-Fill in the [PR template](.github/PULL_REQUEST_TEMPLATE.md) — it mirrors
-`AGENTS.md`'s RECONCILE step: tests pass, lint and typecheck are clean, and a
-changeset is included if the change is user-visible.
+Fill in the [PR template](.github/PULL_REQUEST_TEMPLATE.md): why and what the
+change is, what changed, and any related issues. Before opening it, make sure
+tests, lint, and typecheck pass, and a changeset is included if the change is
+user-visible — that's `AGENTS.md`'s RECONCILE step.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,74 @@
+# Contributing
+
+Thanks for looking into Dunky. This is the fast path to a working setup, the
+commands you'll actually run, and how to file something useful.
+
+For the contribution _workflow_ (SPEC -> TEST -> IMPLEMENT -> RECONCILE), code
+conventions, and boundaries, see [`AGENTS.md`](./AGENTS.md) — it's the same
+contract agents follow here, and it applies to you too.
+
+## Setup
+
+```bash
+git clone git@github.com:dunky-dev/state-machine.git
+cd state-machine
+nvm use          # Node 24, pinned in .nvmrc
+corepack enable  # pnpm 11.10.0, pinned in package.json#packageManager
+pnpm install
+```
+
+## Commands
+
+| Command                        | What it does                                               |
+| ------------------------------ | ---------------------------------------------------------- |
+| `pnpm test`                    | Full test suite, watch mode                                |
+| `pnpm test:ci`                 | Full test suite, once                                      |
+| `pnpm typecheck`               | `tsc -b` across the whole workspace                        |
+| `pnpm lint`                    | `oxlint`                                                   |
+| `pnpm format` / `format:check` | `oxfmt`                                                    |
+| `pnpm build`                   | Build every publishable package                            |
+| `pnpm changeset`               | Add a changeset — see [Versioning](./AGENTS.md#versioning) |
+
+Target one package or one file instead of the whole workspace:
+
+```bash
+pnpm --filter @dunky.dev/state-machine test       # one package's tests
+pnpm vitest packages/core/tests/machine.test.ts    # one test file
+pnpm --filter @dunky.dev/react-state-machine build
+```
+
+## Run the sandboxes
+
+Each sandbox renders the same command-palette machine on a different
+substrate — the fastest way to see a change actually work end to end. See
+[`sandbox/README.md`](./sandbox/README.md) for what each one demonstrates;
+the short version:
+
+```bash
+pnpm -C sandbox/react dev     # DOM   — http://localhost:5173
+pnpm -C sandbox/opentui dev   # terminal — needs Bun
+pnpm -C sandbox/native start  # Expo  — needs a simulator or device
+```
+
+## Filing an issue
+
+A bug report is only as useful as its reproduction. Use an **SSCCE** — Short,
+Self-Contained, Correct (Compilable) Example:
+
+- **Short** — the smallest machine config that still reproduces it. Strip
+  every state, guard, and action that isn't load-bearing.
+- **Self-contained** — no missing imports, no "assume you have X set up."
+  Someone should be able to paste it and run it with nothing else.
+- **Correct (compilable)** — it actually runs and actually reproduces the
+  bug. Not what you _think_ is happening — what you pasted and ran.
+
+The [bug report template](.github/ISSUE_TEMPLATE/bug_report.md) asks for
+exactly this. If you can't shrink your repro to an SSCCE, that's often a sign
+the bug isn't where you think it is — shrinking it is frequently how you find
+the real cause yourself.
+
+## Pull requests
+
+Fill in the [PR template](.github/PULL_REQUEST_TEMPLATE.md) — it mirrors
+`AGENTS.md`'s RECONCILE step: tests pass, lint and typecheck are clean, and a
+changeset is included if the change is user-visible.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,6 @@
 # Contributing
 
-Thanks for looking into Dunky. This is the fast path to a working setup, the
-commands you'll actually run, and how to file something useful.
-
-For the contribution _workflow_ (SPEC -> TEST -> IMPLEMENT -> RECONCILE), code
-conventions, and boundaries, see [`AGENTS.md`](./AGENTS.md) — it's the same
+For the contribution _workflow_, code conventions, and boundaries, see [`AGENTS.md`](./AGENTS.md) — it's the same
 contract agents follow here, and it applies to you too.
 
 ## Setup
@@ -12,8 +8,8 @@ contract agents follow here, and it applies to you too.
 ```bash
 git clone git@github.com:dunky-dev/state-machine.git
 cd state-machine
-nvm use          # Node 24, pinned in .nvmrc
-corepack enable  # pnpm 11.10.0, pinned in package.json#packageManager
+nvm use
+corepack enable
 pnpm install
 ```
 
@@ -31,13 +27,7 @@ pnpm install
 
 Target one package or one file instead of the whole workspace:
 
-```bash
-pnpm --filter @dunky.dev/state-machine test       # one package's tests
-pnpm vitest packages/core/tests/machine.test.ts    # one test file
-pnpm --filter @dunky.dev/react-state-machine build
-```
-
-## Run the sandboxes
+## Sandbox
 
 Each sandbox renders the same command-palette machine on a different
 substrate — the fastest way to see a change actually work end to end. See
@@ -45,9 +35,9 @@ substrate — the fastest way to see a change actually work end to end. See
 the short version:
 
 ```bash
-pnpm -C sandbox/react dev     # DOM   — http://localhost:5173
-pnpm -C sandbox/opentui dev   # terminal — needs Bun
-pnpm -C sandbox/native start  # Expo  — needs a simulator or device
+pnpm -C sandbox/react dev
+pnpm -C sandbox/opentui dev  # terminal — needs Bun
+pnpm -C sandbox/native dev   # Expo  — needs a simulator or device
 ```
 
 ## Filing an issue
@@ -69,7 +59,12 @@ the real cause yourself.
 
 ## Pull requests
 
-Fill in the [PR template](.github/PULL_REQUEST_TEMPLATE.md): why and what the
-change is, what changed, and any related issues. Before opening it, make sure
-tests, lint, and typecheck pass, and a changeset is included if the change is
+Fill in the [PR template](.github/PULL_REQUEST_TEMPLATE.md). Before opening it,
+make sure tests, lint, and typecheck pass, and a changeset is included if the change is
 user-visible — that's `AGENTS.md`'s RECONCILE step.
+
+If you used AI to help write this, read the diff like you wrote it yourself
+before asking someone else to. Cut comments that don't say anything, drop
+anything that drifted from what you're actually fixing, and be able to
+explain any line if asked. A reviewer's time isn't the place to find out you
+didn't.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,12 +59,14 @@ the real cause yourself.
 
 ## Pull requests
 
-Fill in the [PR template](.github/PULL_REQUEST_TEMPLATE.md). Before opening it,
-make sure tests, lint, and typecheck pass, and a changeset is included if the change is
-user-visible — that's `AGENTS.md`'s RECONCILE step.
+### Humans
 
-If you used AI to help write this, read the diff like you wrote it yourself
+When using AI to help write changes, read the diff like you wrote it yourself
 before asking someone else to. Cut comments that don't say anything, drop
 anything that drifted from what you're actually fixing, and be able to
-explain any line if asked. A reviewer's time isn't the place to find out you
-didn't.
+explain any line if asked. A reviewer's time isn't free.
+
+### AI
+
+Before opening it, make sure tests, lint, and typecheck pass, and a changeset is
+included — see `AGENTS.md`'s RECONCILE step.


### PR DESCRIPTION
## Summary

- `CONTRIBUTING.md` — setup (`nvm`/`corepack`/`pnpm install`), the day-to-day commands (test/lint/typecheck/build, filtered to one package or one test file), and how to run each substrate sandbox. Points to `AGENTS.md` for the actual contribution workflow rather than duplicating it.
- `.github/ISSUE_TEMPLATE/bug_report.md` — asks for an **SSCCE** (Short, Self-Contained, Correct/Compilable Example) instead of a free-form description, so reports arrive reproducible.
- `.github/ISSUE_TEMPLATE/config.yml` — keeps blank issues enabled, adds a Discussions link for non-bug questions.
- `.github/PULL_REQUEST_TEMPLATE.md` — a 3-item checklist mirroring `AGENTS.md`'s RECONCILE step (tests/lint/typecheck, cross-scope verification, changeset).

## Test plan
- [x] `pnpm format:check` / `pnpm lint` — clean