### PR TITLE
fix(ci): route deploy-benchmark through the shared ci-setup action

### DIFF
--- a/.github/workflows/deploy-benchmark.yml
+++ b/.github/workflows/deploy-benchmark.yml
@@ -20,18 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10.20.0
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/ci-setup
 
       - name: Build demo
         # The canonical demo ships with the docs site at


### PR DESCRIPTION
## Summary

`deploy-benchmark.yml` failed on every push to `main` with `ERR_PNPM_BAD_PM_VERSION` ("Multiple versions of pnpm specified") — the exact bug fixed in #42, but in a second place #42 never touched: this workflow had its own inline `pnpm/action-setup@v4` + `actions/setup-node@v4` + install steps, duplicating (and drifting from) the shared `ci-setup` composite action, still pinned to `version: 10.20.0` against `packageManager: pnpm@11.10.0`.

Fix: route this workflow through `./.github/actions/ci-setup`, the same composite action `ci-checks.yml` and `release.yml` already use, instead of duplicating pnpm/node/install setup inline. There's now exactly one place a future pnpm bump needs to touch — this can't drift out of sync again.

## Test plan
- [x] `pnpm install` + `pnpm -C benchmark/demo build` — succeeds locally