### PR TITLE
docs: doc refinements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,8 @@ with a tight, obvious scope.
 If the code says what it does, the comment is noise. Write comments to
 explain _why_: a hidden constraint, a subtle invariant, a workaround, a
 hard decision. Keep them short — over-explaining is its own kind of
-noise.
+noise. Don't restate a rule already in `ARCHITECTURE.md`; that
+duplication only drifts out of date — link it or leave it to the doc.
 
 ### Performance
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -148,6 +148,8 @@ surface a view consumes (handlers + attrs per part). This is the layer that
 reads props (see "the machine never sees props" above) and fires the consumer's
 callbacks. It changes when the API surface changes.
 
+### Cross-instance state
+
 Cross-instance singletons (e.g. "only one tooltip open at a time") use
 `createStore` from `@dunky.dev/state-machine` — a tiny reactive cell (plain value +
 listeners) living outside any one machine. Per-machine state is the engine's own


### PR DESCRIPTION
# Why/What

Bringing across the genuinely portable doc refinements that surfaced while working the shared state-machine docs in another worktree. dunky is the source of truth for these files, so most of that work was either substrate-specific or already present here — this PR is only the two deltas that actually improve dunky.

# Changes

- **AGENTS.md** — Comments rule: don't restate a rule already in `ARCHITECTURE.md`; that duplication just drifts out of date.
- **ARCHITECTURE.md** — give the `createStore` paragraph its own **Cross-instance state** subsection, parallel to **Two homes for a side-effect** under **The machine parts** (better structure/TOC).

Docs-only, no published-package change, so no changeset.

## Considered but not ported

- Substrate-specific rules (Stitches logic/styles split, tokens, Radix track, jest-axe, `className`/`asChild`, nvm) — don't apply to this engine repo.
- SPEC/README trims from the other copy (dropped "problem it solves" paragraph, dropped ARCHITECTURE "Vocabulary" table) — dunky's fuller versions are kept.
- A `|_` file-tree diagram convention — skipped: dunky's diagrams consistently use `+--`, and adopting `|_` half-way would contradict existing trees (the source repo doesn't follow it either). Happy to do a full sweep if we want that style.

# Issues

—

🤖 Generated with [Claude Code](https://claude.com/claude-code)