### PR TITLE
docs(opentui): close the parity gaps with the react and native targets

### DIFF
--- a/.changeset/opentui-readme-license.md
+++ b/.changeset/opentui-readme-license.md
@@ -1,0 +1,10 @@
+---
+'@dunky.dev/opentui-state-machine': patch
+---
+
+Ship a README and a LICENSE file with the package. The npm page was blank and
+the package declared `"license": "MIT"` with no license text alongside — both
+now match the react and native packages: the README mirrors their structure
+(quick start, `normalize` and `mergeProps` reference, API table) and documents
+the bring-your-own-lifecycle model, including the module-level, prop-gated
+keyboard-handler pattern that stands in for `ComponentEffect` on a terminal.

--- a/packages/opentui/LICENSE
+++ b/packages/opentui/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ivan Banov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/opentui/README.md
+++ b/packages/opentui/README.md
@@ -1,0 +1,165 @@
+# `@dunky.dev/opentui-state-machine`
+
+The **OpenTUI (terminal) bindings** for [`@dunky.dev/state-machine`](../core/README.md).
+
+The behavior lives in the core machine — plain TypeScript, no renderer. This
+package is **only the prop translator**. Unlike the
+[react](../react/README.md) and [native](../native/README.md) packages it
+ships no `useMachine` hook and has no framework dependency — `normalize` and
+`mergeProps` are pure object-to-object functions, so they work the same under
+any of OpenTUI's reactive bindings (`@opentui/react`, `@opentui/solid`, …):
+
+1. **`normalize`** — translate the machine's agnostic bindings (`onPress`,
+   `hidden`) into OpenTUI props (`onMouseDown`, `visible`).
+2. **`mergeProps`** — merge the consumer's props with the component's,
+   OpenTUI-aware (plain style-object merge).
+
+```
+  core (agnostic)
+  |
+  |   config + connect()      behavior + snapshot -> view api
+  |
+  v
+  your framework binding      e.g. useMachine from the react package
+  |
+  |   api                     the view surface instructions
+  |   |
+  |   v
+  |   normalize()             this package: terminal I/O props
+  |
+  v
+  <box {...props}>
+```
+
+## Quick start — bring your own lifecycle hook
+
+The lifecycle binding — turning the engine's connector into a live
+component — is the consuming app's concern. OpenTUI renders through a React
+reconciler, so the standard pairing is `useMachine` from the **react**
+package plus `normalize` from **this** package:
+
+```tsx
+import { useMachine } from '@dunky.dev/react-state-machine'
+import { normalize } from '@dunky.dev/opentui-state-machine'
+import { createDialogConfig, connectDialog } from './dialog'
+
+function Dialog(props: DialogProps) {
+  const { api, machine } = useMachine(createDialogConfig, connectDialog, [], props)
+
+  return (
+    <box style={{ flexDirection: 'column' }}>
+      <box {...normalize(api.triggerProps)}>
+        <text>Open</text>
+      </box>
+      {api.isOpen && (
+        <box {...normalize(api.contentProps)} style={{ border: true, padding: 1 }}>
+          <text>Dialog content</text>
+        </box>
+      )}
+    </box>
+  )
+}
+```
+
+`useMachine` runs the same shared machine, `connect` produces the same
+logical bindings — only `normalize` and the JSX elements differ from the DOM
+version. The same `createDialogConfig` / `connectDialog` that drive the
+browser drive the terminal, unchanged.
+
+---
+
+## Keyboard handling is global
+
+A terminal has no per-element focus model like the DOM, so key handling
+can't be a listener scoped to one element — and it can't be a
+`ComponentEffect` either: OpenTUI's keyboard input hangs off the renderer,
+which lives in React context, out of reach of an effect tuple's
+`(machine, props)` arguments. Key navigation goes through OpenTUI's
+`useKeyboard` instead.
+
+Keep the `ComponentEffect` discipline anyway: author the handler at module
+level as a prop-gated factory, and feed it to `useKeyboard` in the
+component:
+
+```tsx
+import { useKeyboard } from '@opentui/react'
+import type { KeyEvent } from '@opentui/core'
+
+/** Escape-to-close — the terminal transport for the same close decision. */
+const dialogKeys = (machine: DialogMachine, props: DialogProps) => (key: KeyEvent) => {
+  if (!props.closeOnEscape) return
+  if (machine.matches('open') && key.name === 'escape') {
+    machine.send({ type: 'close' })
+  }
+}
+
+function Dialog(props: DialogProps) {
+  const { api, machine } = useMachine(createDialogConfig, connectDialog, [], props)
+  useKeyboard(dialogKeys(machine, props))
+  // ...
+}
+```
+
+It sends the **same logical events** the DOM version's `ComponentEffect`
+sends — the machine can't tell the difference: three transports (a DOM
+`keydown` effect, RN's `BackHandler`, OpenTUI's `useKeyboard`), the same
+`send({ type: 'close' })`.
+
+---
+
+## `normalize` — agnostic bindings → OpenTUI props
+
+`connect` returns substrate-agnostic bindings; `normalize` translates them
+into OpenTUI's terminal I/O vocabulary — the pointer model is the mouse,
+reported in terminal cells, and there is **no accessibility tree**, so the
+entire ARIA vocabulary is dropped rather than forwarded as props the
+renderer ignores:
+
+```ts
+const tuiProps = normalize(api.triggerProps)
+// { onMouseDown, visible, focusable, ... }
+```
+
+The machine binding maps handlers (`onPress` → `onMouseDown`,
+`onWheel` → `onMouseScroll`, `onValueChange` → `onChange` with the payload
+adapted), and the visual analogs (`hidden` → `visible`, inverted;
+`disabled` and `focusable` pass through).
+[Check out the full mapping here](./src/normalize.ts).
+
+Bindings with no terminal analog (`onFocus`/`onBlur` — OpenTUI signals focus
+via the `focused` **prop** — `onScroll`, `onContextMenu`, and the whole ARIA
+attribute set) are **silently dropped** rather than passed as invalid props.
+`undefined` values are dropped; unknown keys pass through unchanged.
+
+---
+
+## `mergeProps` — consumer props + component props
+
+When a consumer spreads their own props onto an element the component
+controls:
+
+```tsx
+<box {...mergeProps(consumerProps, normalize(api.triggerProps))} />
+```
+
+- **Handlers chain, consumer-first** — both run, unless the consumer's
+  handler marks the event `defaultPrevented`, which skips the library
+  handler (the consumer's veto).
+- **`style` merges into one object** — library wins on conflicting keys.
+  Unlike React Native, OpenTUI's `style` is a plain object, not an array —
+  so styles merge rather than wrap.
+- **Everything else: library wins** — the component owns its semantics.
+
+There is no `className` in a terminal, so — like React Native — there is no
+`className` branch. No consumer props → the library props are returned
+as-is.
+
+---
+
+## API
+
+| Export                          | What it is                                                                                               |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `normalize(bindings)`           | agnostic bindings → OpenTUI props (mouse handlers, `visible`, `focusable`; ARIA dropped)                 |
+| `mergeProps(consumer, library)` | merge consumer + component props (handlers chained w/ `defaultPrevented` veto; plain style-object merge) |
+| `Bindings`                      | `Record<string, unknown>` — the loose shape `normalize` accepts                                          |

--- a/packages/opentui/tests/merge-props.test.ts
+++ b/packages/opentui/tests/merge-props.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, expectTypeOf, it, vi } from 'vitest'
 import { mergeProps } from '@dunky.dev/opentui-state-machine'
 
 describe('mergeProps', () => {
@@ -35,5 +35,18 @@ describe('mergeProps', () => {
   it('does not invent a className branch (terminal has no className)', () => {
     const out = mergeProps({ className: 'a' }, { className: 'b' })
     expect(out.className).toBe('b')
+  })
+})
+
+describe('mergeProps typing', () => {
+  it('preserves a typed consumer through the style merge', () => {
+    interface BoxLikeProps {
+      style?: unknown
+      focusable?: boolean
+    }
+    const consumer: BoxLikeProps = { style: { fg: 'red', padding: 2 } }
+    const out = mergeProps(consumer, { style: { fg: 'blue' } })
+    expectTypeOf(out).toExtend<BoxLikeProps>()
+    expect(out.style).toEqual({ fg: 'blue', padding: 2 })
   })
 })

--- a/packages/react/tests/merge-props.test.ts
+++ b/packages/react/tests/merge-props.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, expectTypeOf, it, vi } from 'vitest'
 import { mergeProps } from '@dunky.dev/react-state-machine'
 
 describe('mergeProps', () => {
@@ -51,5 +51,19 @@ describe('mergeProps', () => {
     // consumer.className is unset; library's wins as a plain key.
     const out = mergeProps({ id: 'a' }, { className: 'x' })
     expect(out.className).toBe('x')
+  })
+})
+
+describe('mergeProps typing', () => {
+  it('preserves a typed consumer through the style merge', () => {
+    interface ButtonLikeProps {
+      style?: unknown
+      className?: string
+      onClick?: () => void
+    }
+    const consumer: ButtonLikeProps = { style: { color: 'red' } }
+    const out = mergeProps(consumer, { style: { color: 'blue' } })
+    expectTypeOf(out).toExtend<ButtonLikeProps>()
+    expect(out.style).toEqual([{ color: 'red' }, { color: 'blue' }])
   })
 })

--- a/sandbox/opentui/src/command-palette.tsx
+++ b/sandbox/opentui/src/command-palette.tsx
@@ -1,4 +1,5 @@
 import { useKeyboard } from '@opentui/react'
+import type { KeyEvent } from '@opentui/core'
 // The opentui package is framework-agnostic — it ships only the prop translator.
 // The lifecycle hook comes from the React binding (OpenTUI renders via a React
 // reconciler), exactly as the opentui package's docs prescribe: bring your own
@@ -7,9 +8,47 @@ import { useMachine } from '@dunky.dev/react-state-machine'
 import { normalize } from '@dunky.dev/opentui-state-machine'
 import {
   commandPaletteMachineConfig,
+  type CommandPaletteMachine,
   type CommandPaletteProps,
   connectCommandPalette,
 } from '@sandbox/cmdk-core'
+
+// Terminal key handling is global (no per-element focus model like the DOM), and
+// it can't be a ComponentEffect: OpenTUI's keyboard hangs off the renderer, which
+// lives in React context, out of reach of an effect tuple. Keep the effect
+// discipline anyway — a module-level factory fed to useKeyboard. It sends the same
+// logical `move`/`execute`/`close` events the DOM input's onKeyDown sends. The
+// machine can't tell the difference.
+const paletteKeys = (machine: CommandPaletteMachine) => (key: KeyEvent) => {
+  const open = machine.matches('open')
+  // Ctrl+K toggles. `super` covers the rare terminal that forwards Cmd via the
+  // Kitty protocol (it lands on `super`, not `meta` — meta is Alt/Option).
+  if (key.name === 'k' && (key.ctrl || key.super)) {
+    machine.send({ type: open ? 'close' : 'open' })
+    return
+  }
+  if (!open) return
+  switch (key.name) {
+    case 'down':
+      machine.send({ type: 'move', to: 'down' })
+      break
+    case 'up':
+      machine.send({ type: 'move', to: 'up' })
+      break
+    case 'home':
+      machine.send({ type: 'move', to: 'first' })
+      break
+    case 'end':
+      machine.send({ type: 'move', to: 'last' })
+      break
+    case 'return':
+      machine.send({ type: 'execute' })
+      break
+    case 'escape':
+      machine.send({ type: 'close' })
+      break
+  }
+}
 
 // The TERMINAL renderer. Identical wiring to the DOM version — `useMachine` runs
 // the SAME shared machine, `connect` produces the SAME logical bindings — only
@@ -21,39 +60,7 @@ export function CommandPalette(props: CommandPaletteProps) {
   // Starts closed — press Ctrl+K to open. (⌘K can't be used in a terminal:
   // macOS/Ghostty don't forward Cmd to the program — Cmd is an app/OS modifier —
   // so terminal palettes use Ctrl+K, exactly like fzf / lazygit.)
-
-  // Terminal key handling is global (no per-element focus model like the DOM), so
-  // navigation goes through useKeyboard → the same logical `move`/`execute`/`close`
-  // events the DOM input's onKeyDown sends. The machine can't tell the difference.
-  useKeyboard(key => {
-    // Ctrl+K toggles. `super` covers the rare terminal that forwards Cmd via the
-    // Kitty protocol (it lands on `super`, not `meta` — meta is Alt/Option).
-    if (key.name === 'k' && (key.ctrl || key.super)) {
-      machine.send({ type: api.open ? 'close' : 'open' })
-      return
-    }
-    if (!api.open) return
-    switch (key.name) {
-      case 'down':
-        machine.send({ type: 'move', to: 'down' })
-        break
-      case 'up':
-        machine.send({ type: 'move', to: 'up' })
-        break
-      case 'home':
-        machine.send({ type: 'move', to: 'first' })
-        break
-      case 'end':
-        machine.send({ type: 'move', to: 'last' })
-        break
-      case 'return':
-        machine.send({ type: 'execute' })
-        break
-      case 'escape':
-        machine.send({ type: 'close' })
-        break
-    }
-  })
+  useKeyboard(paletteKeys(machine))
 
   if (!api.open) {
     // A bare <text> (no wrapping box) so the parent column centers it exactly like

--- a/website/src/content/docs/libs/opentui.mdx
+++ b/website/src/content/docs/libs/opentui.mdx
@@ -19,7 +19,7 @@ import { normalize } from '@dunky.dev/opentui-state-machine'
 import { createDialogConfig, connectDialog } from './dialog'
 
 function Dialog(props: DialogProps) {
-  const { api } = useMachine(createDialogConfig, connectDialog, [], props)
+  const { api, machine } = useMachine(createDialogConfig, connectDialog, [], props)
 
   const triggerProps = normalize(api.triggerProps)
   const contentProps = normalize(api.contentProps)
@@ -43,19 +43,32 @@ function Dialog(props: DialogProps) {
 
 ## Keyboard handling is global
 
-A terminal has no per-element focus model like the DOM, so the dialog's Escape-to-close can't be a `keydown` listener scoped to one element — key navigation goes through OpenTUI's `useKeyboard`. It sends the **same logical events** the DOM version's `ComponentEffect` would — the machine can't tell the difference:
+A terminal has no per-element focus model like the DOM, so the dialog's Escape-to-close can't be a `keydown` listener scoped to one element — and it can't be a `ComponentEffect` either: OpenTUI's keyboard input hangs off the renderer, which lives in React context, out of reach of an effect tuple's `(machine, props)` arguments. Key navigation goes through OpenTUI's `useKeyboard` instead.
+
+Keep the `ComponentEffect` discipline anyway — author the handler at module level as a prop-gated factory, and feed it to `useKeyboard` in the component:
 
 ```tsx
 import { useKeyboard } from '@opentui/react'
+import type { KeyEvent } from '@opentui/core'
 
-useKeyboard(key => {
-  if (api.isOpen && key.name === 'escape') {
+// Module level, like a ComponentEffect: authored once, gated by props.
+const dialogKeys = (machine: DialogMachine, props: DialogProps) => (key: KeyEvent) => {
+  if (!props.closeOnEscape) return
+  if (machine.matches('open') && key.name === 'escape') {
     machine.send({ type: 'close' })
   }
-})
+}
+
+function Dialog(props: DialogProps) {
+  const { api, machine } = useMachine(createDialogConfig, connectDialog, [], props)
+  useKeyboard(dialogKeys(machine, props))
+  // ...
+}
 ```
 
-This is the terminal counterpart to the DOM `onEscapeKey` effect on the [React page](/libs/react) and the `BackHandler` effect on [React Native](/libs/react-native): three different transports, the same `send({ type: 'close' })`.
+It sends the **same logical events** the DOM version's `ComponentEffect` would — the machine can't tell the difference.
+
+This is the terminal counterpart to the DOM `onEscapeKey` effect on the [React page](/libs/react) and the `BackHandler` effect on [React Native](/libs/react-native): three different transports, the same `send({ type: 'close' })`. `ComponentEffect`s still work here for anything that doesn't need the renderer (timers, process signals, terminal resize) — pass them to `useMachine` as usual.
 
 ## `normalize`: bindings → OpenTUI props
 

--- a/website/src/content/docs/libs/react.mdx
+++ b/website/src/content/docs/libs/react.mdx
@@ -106,6 +106,8 @@ and focus (`focusable` → `tabIndex`). [Check out the full mapping here](https:
 When a consumer spreads their own props onto the same element the component controls:
 
 ```tsx
+import { mergeProps, normalize } from '@dunky.dev/react-state-machine'
+
 <button {...mergeProps(props, normalize(api.triggerProps))}>
 ```
 


### PR DESCRIPTION
# Why/What

An audit of the three substrate targets against each other (and against the website) found the code fully in sync but the packaging, docs, and test parity lagging — almost all of it pointing at opentui: no README (blank npm page), no LICENSE despite `"license": "MIT"` in its package.json, a website example that destructures only `{ api }` and then calls `machine.send`, and keyboard handling modeled as ad-hoc inline code where react and native use the `ComponentEffect` discipline.

This PR closes those gaps without changing any runtime behavior.

# Changes

- **`packages/opentui/README.md`** (new) — mirrors the react/native README structure: intro, ASCII flow diagram, bring-your-own-lifecycle quick start, `normalize`/`mergeProps` reference, API table.
- **`packages/opentui/LICENSE`** (new) — the MIT text the other targets got in #44; a patch changeset covers both files shipping to npm.
- **Keyboard-effect discipline** — keyboard input can't be a `ComponentEffect` on a terminal (OpenTUI's keyboard hangs off the renderer, which lives in React context, out of reach of an effect tuple's `(machine, props)`), so the README and the `/libs/opentui` page now document the module-level, prop-gated factory pattern fed to `useKeyboard`, and the opentui sandbox's command palette is refactored to it (`paletteKeys(machine)` at module level, mirroring the react sandbox's `cmdkShortcut`).
- **Website fixes** — the opentui example now destructures `{ api, machine }` (the keyboard snippet below it uses `machine.send`); the react page's `mergeProps` snippet gets its missing import.
- **Type-level guards** — the `expectTypeOf` test for the `mergeProps` generic (#51) existed only in native and shared/utils; react and opentui now have the equivalent, so a regression in their `Props & AnyProps` return type is caught.

Verified: full vitest suite (925 tests / 84 files), `tsc -b`, oxlint, and oxfmt all pass; the opentui sandbox typechecks under its own tsconfig.

# Issues

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)