### PR TITLE
chore: ship the src folder in every published package

### DIFF
--- a/.changeset/publish-src-folder.md
+++ b/.changeset/publish-src-folder.md
@@ -1,0 +1,15 @@
+---
+'@dunky.dev/state-machine': patch
+'@dunky.dev/react-state-machine': patch
+'@dunky.dev/native-state-machine': patch
+'@dunky.dev/opentui-state-machine': patch
+'@dunky.dev/state-machine-utils': patch
+'@dunky.dev/state-machine-bindings': patch
+---
+
+Ship the `src` folder in the published packages, alongside `dist`. The
+READMEs point at source files for the full binding mappings (e.g.
+`./src/normalize.ts`), and those links were dead on the npm page because
+only `dist` was published. The sources are small, plain TypeScript, so the
+readable reference now travels with the package; the build outputs and the
+`exports` map are unchanged.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,7 +8,8 @@
     "directory": "packages/core"
   },
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "type": "module",
   "sideEffects": false,

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -8,7 +8,8 @@
     "directory": "packages/native"
   },
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "type": "module",
   "sideEffects": false,

--- a/packages/opentui/package.json
+++ b/packages/opentui/package.json
@@ -8,7 +8,8 @@
     "directory": "packages/opentui"
   },
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "type": "module",
   "sideEffects": false,

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -8,7 +8,8 @@
     "directory": "packages/react"
   },
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "type": "module",
   "sideEffects": false,

--- a/packages/shared/bindings/package.json
+++ b/packages/shared/bindings/package.json
@@ -8,7 +8,8 @@
     "directory": "packages/shared/bindings"
   },
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "type": "module",
   "sideEffects": false,

--- a/packages/shared/utils/package.json
+++ b/packages/shared/utils/package.json
@@ -8,7 +8,8 @@
     "directory": "packages/shared/utils"
   },
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
# Why/What

The package READMEs point at source files for the full binding mappings (e.g. "[Check out the full mapping here](./src/normalize.ts)"), but only `dist` is published — so those links are dead on the npm page. The sources are small, plain TypeScript; shipping them makes the readable reference travel with the package.

# Changes

- Add `src` to the `files` array of all six publishable packages (`core`, `react`, `native`, `opentui`, `shared/utils`, `shared/bindings`).
- Patch changeset covering all six.

Nothing else changes: build outputs, the `exports` map, and `publishConfig` are untouched — `src` is shipped for reading, not resolved as an entry point. Verified with `npm pack --dry-run` on the react package: 10 files, 32 kB unpacked (5 of them the `src/*.ts` files).

# Issues

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)