### PR TITLE
chore: pin internal workspace deps exact, version independently

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.4/schema.json",
   "changelog": ["@changesets/changelog-github", { "repo": "dunky-dev/state-machine" }],
   "commit": false,
-  "fixed": [["@dunky.dev/*"]],
+  "fixed": [],
   "linked": [],
   "access": "public",
   "baseBranch": "origin/main",

--- a/.changeset/pin-internal-deps.md
+++ b/.changeset/pin-internal-deps.md
@@ -1,0 +1,18 @@
+---
+'@dunky.dev/react-state-machine': patch
+'@dunky.dev/native-state-machine': patch
+'@dunky.dev/opentui-state-machine': patch
+---
+
+Internal dependencies on sibling workspace packages are now pinned to an
+exact version instead of a caret range, and every package versions
+independently — the `@dunky.dev/*` lockstep group is gone, so a release
+never bumps a package whose code didn't change.
+
+A caret range between two packages that both sit above a shared dependency
+lets a consumer's install resolve to two different physical copies of it
+once those packages' required ranges drift apart, silently breaking anything
+identity-sensitive in that shared dependency (a singleton, a `WeakMap`,
+module-level state). Pinning exact collapses that to one resolvable version:
+a mismatch now fails at publish time instead of surfacing as a runtime bug
+in a consumer's app.

--- a/.npmrc
+++ b/.npmrc
@@ -8,5 +8,5 @@ ignore-workspace-root-check=true
 link-workspace-packages=true
 package-manager-strict=false
 prefer-workspace-packages=true
-save-workspace-protocol=rolling
+save-workspace-protocol=true
 strict-peer-dependencies=false

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -182,3 +182,19 @@ whether it needs props/platform or not:
 | **connect**  | A function returning the logical surface a view spreads onto elements.                                                                                                                                                                                                                    |
 | **bindings** | The substrate-agnostic event + attr vocabulary — lives in `shared/bindings`, consumed by every target's normalize. Each ledger is typed by the contract (`HandlerTargets`/`AttrTargets`): every key mapped or a `null` drop — a new binding is a compile error until each target decides. |
 | **compose**  | Run several machines as one unit (orthogonal regions): bundled `start`/`stop` + `sync` + `combine`.                                                                                                                                                                                       |
+
+## Versioning
+
+Every package versions independently; `.changeset/config.json` keeps `fixed`
+and `linked` empty, so no group is ever forced to share a version number —
+an untouched package never gets an empty bump.
+
+Internal workspace dependencies pin exact (`workspace:*`), never a caret
+range (`workspace:^`). Independent versions mean siblings drift apart at
+their own pace, so a caret range between two packages that share a further
+dependency can let a consumer's install resolve to two different physical
+copies of it — a dependency diamond. Anything identity-sensitive further
+down (a singleton, a `WeakMap`, module-level state) breaks silently across
+the two copies. An exact pin collapses the diamond to one resolvable
+version: a mismatch fails at publish time, not at runtime in a consumer's
+app.

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -34,10 +34,10 @@
     "build": "tsdown"
   },
   "dependencies": {
-    "@dunky.dev/react-state-machine": "workspace:^",
-    "@dunky.dev/state-machine": "workspace:^",
-    "@dunky.dev/state-machine-bindings": "workspace:^",
-    "@dunky.dev/state-machine-utils": "workspace:^"
+    "@dunky.dev/react-state-machine": "workspace:*",
+    "@dunky.dev/state-machine": "workspace:*",
+    "@dunky.dev/state-machine-bindings": "workspace:*",
+    "@dunky.dev/state-machine-utils": "workspace:*"
   },
   "peerDependencies": {
     "react": "*",

--- a/packages/opentui/package.json
+++ b/packages/opentui/package.json
@@ -34,7 +34,7 @@
     "build": "tsdown"
   },
   "dependencies": {
-    "@dunky.dev/state-machine-bindings": "workspace:^",
-    "@dunky.dev/state-machine-utils": "workspace:^"
+    "@dunky.dev/state-machine-bindings": "workspace:*",
+    "@dunky.dev/state-machine-utils": "workspace:*"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -34,11 +34,11 @@
     "build": "tsdown"
   },
   "dependencies": {
-    "@dunky.dev/state-machine": "workspace:^",
-    "@dunky.dev/state-machine-utils": "workspace:^"
+    "@dunky.dev/state-machine": "workspace:*",
+    "@dunky.dev/state-machine-utils": "workspace:*"
   },
   "devDependencies": {
-    "@dunky.dev/state-machine-bindings": "workspace:^",
+    "@dunky.dev/state-machine-bindings": "workspace:*",
     "@testing-library/react": "^16.1.0",
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,16 +127,16 @@ importers:
   packages/native:
     dependencies:
       '@dunky.dev/react-state-machine':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../react
       '@dunky.dev/state-machine':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../core
       '@dunky.dev/state-machine-bindings':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../shared/bindings
       '@dunky.dev/state-machine-utils':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../shared/utils
       react:
         specifier: '*'
@@ -148,23 +148,23 @@ importers:
   packages/opentui:
     dependencies:
       '@dunky.dev/state-machine-bindings':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../shared/bindings
       '@dunky.dev/state-machine-utils':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../shared/utils
 
   packages/react:
     dependencies:
       '@dunky.dev/state-machine':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../core
       '@dunky.dev/state-machine-utils':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../shared/utils
     devDependencies:
       '@dunky.dev/state-machine-bindings':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../shared/bindings
       '@testing-library/react':
         specifier: ^16.1.0


### PR DESCRIPTION
Copies the versioning strategy from [dunky-dev/ui#24](https://github.com/dunky-dev/ui/pull/24):

- **`.changeset/config.json`**: the `@dunky.dev/*` `fixed` group is dropped — every package versions independently, so a release never bumps a package whose code didn't change (no more empty `## 0.4.0` changelog headings like core got in #58).
- **`workspace:^` → `workspace:*`** on all internal deps of the published packages (`react` ×3, `native` ×4, `opentui` ×2). Publish now writes exact versions instead of caret ranges: with independent versions, a caret range between siblings above a shared dependency can resolve two physical copies of it in a consumer's install (a dependency diamond), silently breaking anything identity-sensitive — a singleton, a `WeakMap`, module-level state. An exact pin fails at publish time instead.
- **`.npmrc`**: `save-workspace-protocol=rolling` → `true`, so future `pnpm add` of a sibling saves `workspace:*` by default.
- **ARCHITECTURE.md** gains a `## Versioning` section documenting the policy; a changeset covers the three packages whose published manifests change.

Private consumers (`benchmark`, `sandbox/*`, `website`) keep `workspace:^` — they're never published, so the pin is meaningless there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)