### PR TITLE
docs: ACCESSIBILITY.md — the specs every package answers to

### DIFF
--- a/.changeset/native-modal-aria-modal.md
+++ b/.changeset/native-modal-aria-modal.md
@@ -1,0 +1,22 @@
+---
+'@dunky.dev/native-state-machine': minor
+---
+
+The `modal` binding now reaches React Native instead of being dropped:
+`normalize()` maps it to `aria-modal`, the web-aligned alias RN routes to
+`accessibilityViewIsModal`.
+
+```tsx
+normalize({ modal: true }) // { 'aria-modal': true }
+```
+
+It was dropped on the assumption RN had no element-attr analog. It does —
+`aria-modal` sits in the same alias block as `aria-hidden`, which this
+normalizer already targets. The effect is iOS-only (VoiceOver stops reading
+siblings of the modal surface); Android has no sibling-inerting equivalent, so
+it degrades to a no-op there, the same per-platform fan-out `aria-hidden`
+already relies on.
+
+Without it, a dialog authored once in core announced as modal on the web and as
+an ordinary view on native — the substrate-agnostic contract leaking a hole
+exactly where a screen reader user would notice it.

--- a/ACCESSIBILITY.md
+++ b/ACCESSIBILITY.md
@@ -1,0 +1,139 @@
+# Accessibility
+
+## Overview
+
+Dunky is substrate-agnostic; its accessibility contract is not invented here.
+The W3C's web accessibility specs are the baseline for every machine —
+including the ones that never touch a browser.
+
+Behavior is modeled once in `packages/core` and every target inherits it. That
+needs a single external definition of what the behavior _is_, or each host
+drifts toward whatever its platform makes easy. The W3C specs are that
+definition: normative and stable, already mapped onto the native platform
+accessibility APIs by [Core-AAM](https://www.w3.org/TR/core-aam-1.2/), and the
+same documents our consumers audit against. It is why the binding vocabulary in
+`packages/shared/bindings` is ARIA-shaped rather than invented — `role`,
+`labelledBy`, `activeDescendant`, `live` are the spec's terms, minus the
+`aria-` prefix.
+
+So a machine's connector speaks in ARIA terms and holds itself to WCAG. A
+target _translates_ those terms into its host's API through `normalize()` —
+translation may change the words, never the behavior. If a host forces a
+behavioral difference, the decision moves into the core machine, per
+[Boundaries](./AGENTS.md#boundaries).
+
+## References
+
+Primary sources. When shaping an API they are looked up, not recalled.
+
+| Spec                                                | Status                    | What we take from it                                                             |
+| --------------------------------------------------- | ------------------------- | -------------------------------------------------------------------------------- |
+| [WCAG 2.2](https://www.w3.org/TR/WCAG22/)           | Recommendation (2023)     | The success criteria a machine must not violate.                                 |
+| [WAI-ARIA 1.2](https://www.w3.org/TR/wai-aria-1.2/) | Recommendation (2023)     | The role, state, and property vocabulary the core machine emits.                 |
+| [UAAG 2.0](https://www.w3.org/TR/UAAG20/)           | Working Group Note (2015) | User-agent obligations we must not break or duplicate.                           |
+| [ATAG 2.0](https://www.w3.org/TR/ATAG20/)           | Recommendation (2015)     | What lands on us when a consumer builds an authoring tool from these primitives. |
+| [WCAG 3.0](https://www.w3.org/TR/wcag-3.0/)         | Working Draft             | Direction of travel only — never cite it as a requirement.                       |
+
+Version notes, so nobody re-litigates them per package: **WAI-ARIA is pinned
+to 1.2** — 1.1 is superseded, and [1.3](https://www.w3.org/TR/wai-aria-1.3/)
+is a draft read for direction like WCAG 3.0. **WCAG 2.2 is a Recommendation**,
+not a candidate one, and it is the bar.
+
+Supporting, but repeatedly load-bearing:
+
+- [APG](https://www.w3.org/WAI/ARIA/apg/) — the patterns. **Advisory**: we
+  follow it by default, but a normative spec wins any conflict.
+- [Accname](https://www.w3.org/TR/accname-1.2/) — how a name resolves. Needed
+  by any machine with a labelling API.
+- [WCAG2ICT](https://www.w3.org/TR/wcag2ict/) — applying WCAG to non-web
+  software; why a native or terminal target is held to WCAG at all.
+- [ARIA in HTML](https://www.w3.org/TR/html-aria/) and
+  [`inert`](https://html.spec.whatwg.org/multipage/interaction.html#inert) —
+  web target only.
+
+## Packages
+
+A `SPEC.md` sets a `## Reference` section when an external reference anchors
+its surface, linking it. (Per [SPEC](./AGENTS.md#spec), don't add a `SPEC.md`
+to a package that has none without asking.) For the binding vocabulary the
+reference is inline: each ARIA-derived key in
+`packages/shared/bindings/src/index.ts` names the ARIA term it carries.
+
+The API must cross-match the reference: every user/dev semantics traces to a
+referenced rule or is deliberately ours; every referenced rule is met; the
+spec's names win unless there's a reason — and an ARIA-derived key keeps the
+spec's meaning _and_ its value domain, not just its name. **Where the API and a
+normative spec disagree, the API is the bug if not explicitly justified**.
+
+A deliberate deviation is justified where it lives: in that package's SPEC, or
+next to the key it affects in the vocabulary.
+
+## Non-web substrates
+
+Same behavior, same outcomes. What changes is the API it speaks. Each target's
+`normalize()` is the entire translation surface, so the maps in it are the
+record:
+
+- **Mapping** — the ARIA term has a platform counterpart, so the target
+  translates. The normal case; no justification needed.
+
+  ```
+  hidden: true
+    |
+    +-- react   -> aria-hidden
+    +-- native  -> aria-hidden      (RN's web-aligned alias, fanned out per platform)
+    +-- opentui -> visible={false}  (no accessibility tree; the visual analog)
+  ```
+
+  Where the mapping isn't mechanical — RN folding `disabled`/`expanded`/
+  `selected`/`checked`/`busy` into `accessibilityState`, ARIA `live: 'off'`
+  becoming RN's `'none'`, `focusable` becoming `tabIndex` on the DOM and
+  `focusable` + `accessible` on RN — the target's `normalize()` header carries
+  the note.
+
+- **Extra instruction** — the platform adds obligations the web doesn't (touch
+  targets, gestures, hardware Back, VoiceOver/TalkBack idioms). Additive, and
+  documented in the target's own docs, per
+  [Apple](https://developer.apple.com/design/human-interface-guidelines/accessibility),
+  [Android](https://developer.android.com/guide/topics/ui/accessibility), and
+  [React Native](https://reactnative.dev/docs/accessibility). It must not
+  contradict the core contract.
+- **Override** — a referenced rule genuinely can't hold here: the host lacks
+  the premise (no accessibility tree in a terminal) or its own contract wins
+  (the system Back gesture). Record it next to the API it affects: the rule,
+  what happens instead, why the host forces it, and what the user still gets.
+  An override reinterprets a _mechanism_; a different _decision_ is a core
+  change.
+- **Anything that doesn't port gets recorded, not skipped** — that is what
+  `HANDLER_DROP` and `ATTR_DROP` are for. They're typed against the vocabulary
+  (`HandlerKey` / `AttrKey`), so a drop is a named decision and a typo'd or
+  unknown key is a compile error instead of a silent leak. The accounting is
+  deliberately _not_ exhaustive at the type level — a target is not forced to
+  answer every key — so when the vocabulary grows, walking each target is part
+  of the change, not something the compiler will do for you. A silent gap is
+  indistinguishable from an oversight.
+
+Terminal UIs are the sharpest case: no ARIA, no accessibility tree, no
+normative spec — `opentui` drops the whole attribute vocabulary. What survives
+is the technology-independent WCAG criteria (via WCAG2ICT) plus the terminal's
+own behavior.
+
+## Audit
+
+Accessibility claims are behavior, so they're tested like behavior — in `TEST`,
+before the implementation exists.
+
+- **Core** — the semantics the machine emits: resolved role, name and
+  description references, which states gate which transitions, the keyboard
+  contract.
+- **Target** — the translation, against what the host consumes: ARIA
+  attributes and focus order on the DOM, real native props on native, real
+  widget props in the terminal. A drop is asserted too — a dropped key must not
+  leak through as an invalid host prop.
+- **Device / browser** — what a mocked host can't reach: real screen readers,
+  real hardware Back, real touch. The per-substrate apps in `sandbox/` are
+  where that happens.
+
+Automated checks catch missing names and invalid attributes. They don't catch a
+focus order that makes no sense or an announcement that misleads — those need a
+citation and a human.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,13 @@ inside each `it()`. Reusable multi-file fixtures go in
 `tests/fixtures/` — anything shared across test files lives there, not
 inlined or duplicated.
 
+## Accessibility
+
+Accessibility is referenced, not improvised — the external specs are the
+contract, and the API is cross-matched against them.
+[`ACCESSIBILITY.md`](./ACCESSIBILITY.md) is the reference: read it before
+designing a public API.
+
 ## Versioning
 
 Every PR with a user-visible change to a public package needs a

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ The full layered model and the "the machine never sees props" rule are in:
 - **[`ARCHITECTURE.md`](./ARCHITECTURE.md)** — the big-picture map and the layered model.
 - **[`packages/core/README.md`](./packages/core/README.md)** — the state machine engine and its full API.
 - **[`benchmark/README.md`](./benchmark/README.md)** — what's measured, the methodology, and results vs. XState & Zag.
+- **[`ACCESSIBILITY.md`](./ACCESSIBILITY.md)** — the external specs every package answers to.
 - **[`AGENTS.md`](./AGENTS.md)** — the contributor / agent contract.
 
 ## Inspiration & prior art

--- a/packages/native/src/normalize.ts
+++ b/packages/native/src/normalize.ts
@@ -27,11 +27,12 @@
  * - No hover — pointer move/enter/leave/cancel are dropped.
  * - `onContextMenu` → `onLongPress`; `onDoublePress`/`onWheel` dropped (no RN analog).
  * - `expanded`/`selected`/`disabled`/`checked`/`busy` fold into `accessibilityState`.
- * - `hidden` → `aria-hidden`: the web-aligned alias RN fans out per platform.
+ * - `hidden` → `aria-hidden` and `modal` → `aria-modal`: web-aligned aliases RN
+ *   fans out per platform.
  * - `valueMin`/`valueMax`/`valueNow`/`valueText` fold into `accessibilityValue`.
  * - `live` → `accessibilityLiveRegion`; `'off'` → `'none'`.
- * - `controls`/`hasPopup`/`modal`/`describedBy` and most ARIA-only attrs are
- *   dropped (`describedBy`: RN has no describe-by-reference slot).
+ * - `controls`/`hasPopup`/`describedBy` and most ARIA-only attrs are dropped
+ *   (`describedBy`: RN has no describe-by-reference slot).
  * - `role` passes through unchanged: RN's web-aligned `role` prop takes the
  *   full ARIA vocabulary and degrades gracefully, while the legacy
  *   `accessibilityRole` enum throws natively on Android for values outside
@@ -79,6 +80,9 @@ export const ATTR_MAP: AttrTargets = {
   // per platform (accessibilityElementsHidden on iOS, no-hide-descendants on
   // Android) — accessibilityState has no hidden slot.
   hidden: 'aria-hidden',
+  // Same alias block as aria-hidden; RN routes it to accessibilityViewIsModal,
+  // which is iOS-only — Android has no sibling-inerting equivalent to fan out to.
+  modal: 'aria-modal',
   role: 'role', // the web-aligned prop — never the legacy accessibilityRole enum (throws)
   // `focusable` and `live` are special-cased in normalize(): the value is
   // transformed (coerced boolean + `accessible`; ARIA 'off' → RN 'none').
@@ -89,7 +93,6 @@ export const ATTR_DROP: ReadonlySet<string> = new Set<AttrKey>([
   'describedBy',
   'controls',
   'hasPopup',
-  'modal',
   'pressed',
   'current',
   'invalid',

--- a/packages/native/tests/normalize.test.ts
+++ b/packages/native/tests/normalize.test.ts
@@ -101,6 +101,12 @@ describe('native normalize — attributes', () => {
     expect(normalize({ hidden: true })).toEqual({ 'aria-hidden': true })
   })
 
+  it('maps modal to aria-modal', () => {
+    // RN routes aria-modal to accessibilityViewIsModal (iOS); Android has no
+    // sibling-inerting equivalent, so it degrades to a no-op there.
+    expect(normalize({ modal: true })).toEqual({ 'aria-modal': true })
+  })
+
   it('omits accessibilityState entirely when no a11y-state keys are present', () => {
     const out = normalize({ role: 'menu' })
     expect('accessibilityState' in out).toBe(false)
@@ -142,13 +148,9 @@ describe('native normalize — combined surface (tooltip content shape)', () => 
 })
 
 describe('native normalize — DOM-ARIA-only attrs are dropped', () => {
-  it('drops controls / hasPopup / modal (no RN element-attr analog)', () => {
-    const out = normalize({ controls: 'menu:1:content', hasPopup: 'menu', modal: true })
+  it('drops controls / hasPopup (no RN element-attr analog)', () => {
+    const out = normalize({ controls: 'menu:1:content', hasPopup: 'menu' })
     expect(out).toEqual({})
-  })
-
-  it('does not leak modal as an invalid RN prop', () => {
-    expect('modal' in normalize({ modal: true })).toBe(false)
   })
 
   it('drops the ARIA attrs RN has no slot for', () => {

--- a/packages/react/src/normalize.ts
+++ b/packages/react/src/normalize.ts
@@ -1,4 +1,22 @@
-// Translate the machine layer's logical surface to React DOM props.
+/**
+ * Translate the machine layer's logical surface to React DOM props.
+ *
+ * Input keys are the substrate-agnostic vocabulary a connect() emits
+ * (`EventBindings` / `AttrBindings` in `@dunky.dev/state-machine-bindings`),
+ * which is ARIA-shaped by design — see `ACCESSIBILITY.md`. The DOM is the
+ * closest host to that vocabulary, so most attrs are a mechanical `aria-`
+ * prefix and nothing is dropped. The parts that aren't mechanical:
+ * - `onPress` → `onClick`: the DOM's activation event, which fires for
+ *   keyboard Enter/Space on a native control too, not just a mouse press.
+ * - `focusable` → `tabIndex` 0 / -1, not a boolean — `false` still has to
+ *   leave the element focusable in script.
+ * - `disabled` → `aria-disabled`, never the HTML `disabled` attribute: a
+ *   disabled control stays in the tab order and keeps announcing itself,
+ *   per APG. A consumer that wants the HTML attribute passes it themselves.
+ * - `onValueChange`/`onWheel`/`onScroll`/`onScrollEnd` also have their
+ *   argument translated — the DOM event is read into the neutral payload
+ *   shape (see PAYLOAD_ADAPTERS), never forwarded raw.
+ */
 import type {
   AttrKey,
   AttrTargets,

--- a/packages/shared/bindings/src/index.ts
+++ b/packages/shared/bindings/src/index.ts
@@ -1,5 +1,10 @@
 // Substrate-agnostic binding vocabulary: event handlers and attributes a connect() emits.
 // Each renderer's normalize() is the only code that turns these into platform props.
+//
+// The attribute half is WAI-ARIA 1.2 (https://www.w3.org/TR/wai-aria-1.2/) with the
+// `aria-` prefix dropped and the names camelCased — the spec's terms and its value
+// domains, not invented ones, so a key means on every substrate what it means there.
+// Deviations are justified on the key itself. See ACCESSIBILITY.md at the repo root.
 
 export interface PointerPayload {
   /** True when an upstream handler called preventDefault / equivalent. */


### PR DESCRIPTION
# Why/What

Accessibility was improvised per target. This makes it referenced: `ACCESSIBILITY.md` names the external specs every package answers to — WCAG 2.2, WAI-ARIA 1.2, UAAG 2.0, ATAG 2.0, with WCAG 3.0 read for direction only — and states the rule that where the API and a normative spec disagree, the API is the bug unless justified.

Ported from [dunky-dev/ui@9df7999](https://github.com/dunky-dev/ui/commit/9df7999630663ff9f859ebc02448859a083e613c) and adapted to this repo: the ARIA anchor here is the binding vocabulary in `packages/shared/bindings`, not per-primitive specs.

Then reconciled every package against the rules the doc states, which surfaced one real bug.

# Changes

**The doc**

- `ACCESSIBILITY.md` — the specs, the version pins (ARIA is 1.2, not 1.1 or the 1.3 draft), how a reference enters a package, what a non-web target may do differently (map / add platform instruction / override with a recorded reason), and the audit layers.
- `AGENTS.md`, `README.md` — pointers to it.

The doc is explicit that the drop sets are **not** exhaustive at the type level. Forcing every target to answer every key is the 0.4.0 contract that #60 rolled back on purpose; walking the targets stays a manual step when the vocabulary grows.

**One real bug: `packages/native` was dropping `modal`**

RN has the slot. `aria-modal` is declared in `ViewAccessibility.d.ts:95`, in the same web-aligned alias block as `aria-hidden` — which this normalizer already targets — and RN routes it to `accessibilityViewIsModal`. The drop assumed no analog existed.

Effect: a dialog authored once in core announced as modal on the web and as an ordinary view on native.

iOS-only, as ARIA modality is on RN: VoiceOver stops reading siblings of the modal surface. Android has no sibling-inerting equivalent, so it degrades to a no-op — the same per-platform fan-out `aria-hidden` already relies on. Verified against the vendored RN 0.81.4 typings, per the normalizer's own "verify against source, not docs" rule.

**Two headers brought up to the rule the doc states**

- `packages/react/src/normalize.ts` had a one-line header while native and opentui carry full ones. Now documents its non-mechanical mappings: `onPress`→`onClick`, `focusable`→`tabIndex` 0/-1, `disabled`→`aria-disabled` (never the HTML attribute, per APG), and the payload adapters.
- `packages/shared/bindings/src/index.ts` is ARIA-derived but never cited the spec. Now does.

# Checked, no change needed

- All 43 attr keys cross-matched against WAI-ARIA 1.2 — `hasPopup`, `current`, `invalid`, `sort`, `autoComplete`, `checked`, `pressed`, `live`, `orientation` all carry the spec's exact value sets. No drift.
- All three targets already account for all 43 attrs and all 17 handlers.
- `packages/react` drops nothing; `onScrollEnd` confirmed real in React 19.
- `packages/opentui` dropping the whole ARIA attr set is correct — no accessibility tree in a terminal.
- Every remaining `packages/native` drop checked against RN's full accessibility prop surface. No slot exists for any of them.
- `packages/core` is the pure engine, no a11y surface.

# Follow-up, not in this PR

Five WAI-ARIA 1.2 attributes have no vocabulary key: `aria-keyshortcuts`, `aria-roledescription`, `aria-details`, `aria-placeholder`, `aria-relevant`. Not defects — nothing emits them yet — but adding a key obliges all three targets to answer it, so it's a separate decision.

Note: [dunky-dev/ui@148ee66](https://github.com/dunky-dev/ui/commit/148ee66481f70852734a77814643814af5b339fc) (the `<dialog>` → `<div role="dialog">` fix) has no counterpart here — no dialog package, and `mergeProps` is already generic.

# Issues

<!-- none -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)