### PR TITLE
docs(agents): principles table — KISS, DRY, YAGNI, POLA

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,6 @@ works, written once, built only when needed, behaving as promised:
 | **KISS**  | Keep it simple. Prefer the plain solution over the clever one; complexity must earn its keep with a need the simple version can't meet.                         |
 | **DRY**   | Don't repeat yourself. A rule two places must agree on is written once and shared — duplication is where the copies drift apart.                                |
 | **YAGNI** | You aren't gonna need it. Build for the requirement in front of you, not the one imagined; speculative machinery is deleted-on-sight, not kept just in case.    |
-| **POLA**  | Principle of least astonishment. A thing does what its name and shape promise — no hidden side effects, no behavior a reader wouldn't guess from the call site. |
 
 ### Naming
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,18 @@ TEST; if not, ship it!
 
 ## Code
 
+### Principles
+
+Every change is held to these four, in this order — simplest thing that
+works, written once, built only when needed, behaving as promised:
+
+| Principle | Meaning                                                                                                                                                         |
+| --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **KISS**  | Keep it simple. Prefer the plain solution over the clever one; complexity must earn its keep with a need the simple version can't meet.                         |
+| **DRY**   | Don't repeat yourself. A rule two places must agree on is written once and shared — duplication is where the copies drift apart.                                |
+| **YAGNI** | You aren't gonna need it. Build for the requirement in front of you, not the one imagined; speculative machinery is deleted-on-sight, not kept just in case.    |
+| **POLA**  | Principle of least astonishment. A thing does what its name and shape promise — no hidden side effects, no behavior a reader wouldn't guess from the call site. |
+
 ### Naming
 
 Descriptive names everywhere. Short names are fine for local variables


### PR DESCRIPTION
Adds a Principles section at the top of `## Code` in `AGENTS.md`: a table holding every change to KISS, DRY, YAGNI, and POLA, each with a one-line meaning. Mirrors dunky-dev/ui#55 so the working contract is the same across the dunky repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)