### PR TITLE
refactor(core): simpler after-timer dispatch, fewer per-event allocations

### DIFF
--- a/.changeset/after-timers-join-queue.md
+++ b/.changeset/after-timers-join-queue.md
@@ -1,0 +1,11 @@
+---
+'@dunky.dev/state-machine': patch
+---
+
+Internal cleanup of the core machine. `after` timers now dispatch through
+the same run-to-completion queue as `send`, instead of running their own
+copy of the flush cycle; the stale-timer check keeps only the entry
+generation, which already covers "state exited" and "state re-entered".
+`send` and `setContext` are plain bound fields (no pass-through hops), the
+boot event is one shared frozen object, and `oneOf` picks its branch with
+a loop instead of `find`. No behavior change for consumers.

--- a/.changeset/core-hot-path-allocations.md
+++ b/.changeset/core-hot-path-allocations.md
@@ -1,0 +1,12 @@
+---
+'@dunky.dev/state-machine': patch
+---
+
+Fewer allocations on the send path. A single action or transition entry is
+run directly instead of being wrapped in a one-item array per event; guard
+params are built only when a guard is actually met; the action and computed
+hosts hold the live context and computed objects instead of reading them
+through getter functions; the connector builds its snapshot argument once
+and compares props without allocating key arrays. Single-event throughput
+is up about 7% and state churn about 10% on the benchmark suite. No
+behavior change for consumers.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,11 +111,11 @@ TEST; if not, ship it!
 Every change is held to these four, in this order — simplest thing that
 works, written once, built only when needed, behaving as promised:
 
-| Principle | Meaning                                                                                                                                                         |
-| --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **KISS**  | Keep it simple. Prefer the plain solution over the clever one; complexity must earn its keep with a need the simple version can't meet.                         |
-| **DRY**   | Don't repeat yourself. A rule two places must agree on is written once and shared — duplication is where the copies drift apart.                                |
-| **YAGNI** | You aren't gonna need it. Build for the requirement in front of you, not the one imagined; speculative machinery is deleted-on-sight, not kept just in case.    |
+| Principle | Meaning                                                                                                                                                      |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **KISS**  | Keep it simple. Prefer the plain solution over the clever one; complexity must earn its keep with a need the simple version can't meet.                      |
+| **DRY**   | Don't repeat yourself. A rule two places must agree on is written once and shared — duplication is where the copies drift apart.                             |
+| **YAGNI** | You aren't gonna need it. Build for the requirement in front of you, not the one imagined; speculative machinery is deleted-on-sight, not kept just in case. |
 
 ### Naming
 

--- a/packages/core/SPEC.md
+++ b/packages/core/SPEC.md
@@ -191,7 +191,7 @@ method names it exposes.
 
 ### Run-to-completion
 
-- Dispatching an event **enqueues** it; the queue is drained one item at a
+- Dispatching an event **enqueues** it; the queue is flushed one item at a
   time. An event dispatched from inside an action, effect, or watcher is
   appended and processed after the current item finishes — never
   interleaved. The state graph is never observed mid-transition.

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -64,10 +64,12 @@ export function runAction<Context extends object, Event, Computed>(
 ): void {
   if (isOneOf(action)) {
     const params = makeGuardParams(host.context(), event, host.computed(), host.guards)
-    const branch = action.branches.find(b =>
-      b.guard ? resolveGuard(b.guard, params, host.guards) : true,
-    )
-    if (branch) runActions(host, branch.actions, event)
+    for (const branch of action.branches) {
+      if (!branch.guard || resolveGuard(branch.guard, params, host.guards)) {
+        runActions(host, branch.actions, event)
+        return
+      }
+    }
     return
   }
   const named = action as Exclude<typeof action, OneOf<Context, Event, Computed>>

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -48,11 +48,12 @@ export function isOneOf<Context extends object, Event, Computed>(
   )
 }
 
+// `context` / `computed` are the live objects — their identity never changes, so no getter.
 export interface ActionHost<Context extends object, Event, Computed> {
   actions: Record<string, Action<Context, Event, Computed>> | undefined
   guards: Record<string, Guard<Context, Event, Computed>> | undefined
-  context: () => Context
-  computed: () => Computed
+  context: Context
+  computed: Computed
   setContext: (patch: Partial<Context>) => void
   send: (event: Event) => void
 }
@@ -63,7 +64,7 @@ export function runAction<Context extends object, Event, Computed>(
   event: Event,
 ): void {
   if (isOneOf(action)) {
-    const params = makeGuardParams(host.context(), event, host.computed(), host.guards)
+    const params = makeGuardParams(host.context, event, host.computed, host.guards)
     for (const branch of action.branches) {
       if (!branch.guard || resolveGuard(branch.guard, params, host.guards)) {
         runActions(host, branch.actions, event)
@@ -81,11 +82,11 @@ export function runAction<Context extends object, Event, Computed>(
     return
   }
   fn({
-    context: host.context(),
+    context: host.context,
     setContext: host.setContext,
     event,
     send: host.send,
-    computed: host.computed(),
+    computed: host.computed,
   })
 }
 
@@ -95,6 +96,6 @@ export function runActions<Context extends object, Event, Computed>(
   event: Event,
 ): void {
   if (!actions) return
-  const list = Array.isArray(actions) ? actions : [actions]
-  for (const action of list) runAction(host, action, event)
+  if (!Array.isArray(actions)) return runAction(host, actions, event)
+  for (const action of actions) runAction(host, action, event)
 }

--- a/packages/core/src/computed.ts
+++ b/packages/core/src/computed.ts
@@ -1,8 +1,9 @@
 import type { ComputedDefs } from './types'
 
+// `context` / `computed` are the live objects (stable identity); only state is read through a fn.
 export interface ComputedHost<State extends string, Context, Computed> {
-  context: () => Context
-  computed: () => Computed
+  context: Context
+  computed: Computed
   state: () => State
 }
 
@@ -19,8 +20,8 @@ export function defineComputed<State extends string, Context extends object, Com
 ): void {
   // Dep keys are runtime strings, so all dep reads are string-indexed — widen once here
   // instead of casting at every read site. The proxy target is inert (traps never touch it).
-  const contextOf = host.context as () => Record<string, unknown>
-  const computedOf = host.computed as () => Record<string, unknown>
+  const context = host.context as Record<string, unknown>
+  const computed = host.computed as Record<string, unknown>
   const proxyTarget: Record<string, unknown> = {}
 
   for (const key in defs) {
@@ -44,7 +45,7 @@ export function defineComputed<State extends string, Context extends object, Com
     let tracking = false
     const trackedCtx = new Proxy(proxyTarget, {
       get: (_t, p: string) => {
-        const value = contextOf()[p]
+        const value = context[p]
         if (tracking && !ctxDeps.includes(p)) {
           ctxDeps.push(p)
           ctxVals.push(value)
@@ -55,7 +56,7 @@ export function defineComputed<State extends string, Context extends object, Com
 
     const trackedComputed = new Proxy(proxyTarget, {
       get: (_t, p: string) => {
-        const value = computedOf()[p]
+        const value = computed[p]
         if (tracking && !computedDeps.includes(p)) {
           computedDeps.push(p)
           computedVals.push(value)
@@ -76,16 +77,14 @@ export function defineComputed<State extends string, Context extends object, Com
 
     const stale = (): boolean => {
       if (readState && stateSnapshot !== host.state()) return true
-      const ctx = contextOf()
 
       let i = 0
       while (i < ctxDeps.length) {
-        if (!Object.is(ctxVals[i], ctx[ctxDeps[i]!])) return true
+        if (!Object.is(ctxVals[i], context[ctxDeps[i]!])) return true
         i++
       }
 
       // Reading a computed dep resolves ITS staleness first — transitive changes surface here.
-      const computed = computedOf()
       i = 0
       while (i < computedDeps.length) {
         if (!Object.is(computedVals[i], computed[computedDeps[i]!])) return true

--- a/packages/core/src/connector.ts
+++ b/packages/core/src/connector.ts
@@ -22,25 +22,25 @@ export function connector<
 
   let cached: Api
   let dirty = true
-  const rebuild = (): Api =>
-    connect({
-      get state() {
-        return service.state
-      },
-      get context() {
-        return service.context
-      },
-      get computed() {
-        return service.computed
-      },
-      get props() {
-        return props
-      },
-      send: service.send,
-    })
+  // Built once — the getters read live values, so every rebuild can reuse the same object.
+  const connectArg = {
+    get state() {
+      return service.state
+    },
+    get context() {
+      return service.context
+    },
+    get computed() {
+      return service.computed
+    },
+    get props() {
+      return props
+    },
+    send: service.send,
+  }
   const snapshot = (): Api => {
     if (dirty) {
-      cached = rebuild()
+      cached = connect(connectArg)
       dirty = false
     }
     return cached
@@ -91,16 +91,17 @@ export function connector<
   }
 }
 
+// Runs on every render (setProps) — two for..in passes with a key counter, no key arrays.
 function shallowEqual(a: unknown, b: unknown): boolean {
   if (Object.is(a, b)) return true
   if (typeof a !== 'object' || a === null || typeof b !== 'object' || b === null) return false
-  const ak = Object.keys(a as object)
-  const bk = Object.keys(b as object)
-  if (ak.length !== bk.length) return false
-  for (const k of ak) {
-    if (!Object.is((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k])) {
-      return false
-    }
+  const left = a as Record<string, unknown>
+  const right = b as Record<string, unknown>
+  let extraKeys = 0
+  for (const k in left) {
+    if (!Object.is(left[k], right[k])) return false
+    extraKeys++
   }
-  return true
+  for (const _ in right) extraKeys--
+  return extraKeys === 0
 }

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -13,10 +13,10 @@ export const MACHINE_INIT = 'machine.init' as const
 export const isDev: boolean = process.env.NODE_ENV !== 'production'
 
 /**
- * Dev-only runaway guard for one queue drain. A single send legitimately chains
+ * Dev-only runaway guard for one queue flush. A single send legitimately chains
  * a handful of queued events / deferred watcher runs; thousands means a
  * feedback loop (e.g. a watcher whose action keeps changing the field it
  * watches, or actions sending in a cycle). Far above any real chain, so a hit
  * is always a bug.
  */
-export const MAX_DRAIN = 10_000
+export const MAX_FLUSH = 10_000

--- a/packages/core/src/machine.ts
+++ b/packages/core/src/machine.ts
@@ -1,7 +1,7 @@
 import { type ActionHost, runActions } from './actions'
 import { makeBroadcast } from './broadcast'
 import { defineComputed } from './computed'
-import { isDev, MACHINE_INIT, MAX_DRAIN } from './constants'
+import { isDev, MACHINE_INIT, MAX_FLUSH } from './constants'
 import { makeGuardParams } from './guards'
 import { shouldPatch } from './patch'
 import { makeSelection } from './selection'
@@ -135,23 +135,23 @@ class MachineClass<
       if (this.running) this.startEffects(next, event)
     }
   }
-  // Re-entrant enqueues (send from an action, watcher mid-transition) wait for the current drain.
+  // Re-entrant enqueues (send from an action, watcher mid-transition) wait for the current flush.
   private enqueue(item: Event | (() => void)): void {
     this.queue.push(item)
     if (this.flushing) return
     this.flushing = true
     try {
-      this.drainQueue()
+      this.flushQueue()
     } finally {
       this.flushing = false
     }
   }
-  private drainQueue(): void {
+  private flushQueue(): void {
     let ticks = 0
     while (this.queue.length) {
-      if (isDev && ++ticks > MAX_DRAIN) {
+      if (isDev && ++ticks > MAX_FLUSH) {
         throw new Error(
-          `[machine] one drain exceeded ${MAX_DRAIN} steps — feedback loop ` +
+          `[machine] one flush exceeded ${MAX_FLUSH} steps — feedback loop ` +
             '(e.g. a watcher writing the field it watches, or actions sending in a cycle)',
         )
       }

--- a/packages/core/src/machine.ts
+++ b/packages/core/src/machine.ts
@@ -31,6 +31,9 @@ function tagsForStates<State extends string>(
   return tags
 }
 
+// One shared instance — the boot event carries no payload, so nothing needs a fresh object.
+const INIT_EVENT = Object.freeze({ type: MACHINE_INIT })
+
 class MachineClass<
   State extends string,
   Context extends object,
@@ -57,8 +60,6 @@ class MachineClass<
   startListeners: Set<() => void> | null = null
   stopListeners: Set<() => void> | null = null
   computed: Computed
-  setContext: (patch: Partial<Context>) => void
-  send: (event: Event) => void
   actionHost: ActionHost<Context, Event, Computed>
 
   constructor(config: TransitionConfig<State, Context, Event, Computed>) {
@@ -83,20 +84,18 @@ class MachineClass<
       guards: config.implementations?.guards,
       context: () => this.ctx,
       computed: () => this.computed,
-      setContext: p => this.setContext(p),
-      send: e => this.send(e),
+      setContext: this.setContext,
+      send: this.send,
     }
-
-    this.setContext = patch => {
-      if (!shouldPatch(this.ctx, patch)) return
-      Object.assign(this.ctx, patch) // in place — this.ctx identity never changes
-      this.notify()
-    }
-    this.send = event => this.doSend(event)
   }
 
-  private notify(): void {
+  setContext = (patch: Partial<Context>): void => {
+    if (!shouldPatch(this.ctx, patch)) return
+    Object.assign(this.ctx, patch) // in place — this.ctx identity never changes
     this.broadcast.notify()
+  }
+  send = (event: Event): void => {
+    this.enqueue(event)
   }
 
   get state(): State {
@@ -115,7 +114,7 @@ class MachineClass<
   private setState(next: State): void {
     if (next === this.stateValue) return
     this.stateValue = next
-    this.notify()
+    this.broadcast.notify()
   }
 
   // Guard params are built lazily — guardless transitions (the common case) never allocate them.
@@ -186,10 +185,6 @@ class MachineClass<
       if (t) this.applyTransition(t, item)
     }
   }
-  private doSend(event: Event): void {
-    this.enqueue(event)
-  }
-
   private resolveDelay(key: string, event: Event): number {
     const asNum = Number(key)
     if (!Number.isNaN(asNum)) return asNum
@@ -202,24 +197,12 @@ class MachineClass<
     }
     return fn(makeGuardParams(this.ctx, event, this.computed, this.config.implementations?.guards))
   }
+  // Runs as a queued job so the timer joins the run-to-completion queue like any send.
+  // Stale when the machine stopped or the state was exited (and maybe re-entered) since scheduling.
   private dispatchAfter(scheduledIn: State, key: string, event: Event, generation: number): void {
-    // Stale timer: machine stopped, moved to a different state, or re-entered the same state.
-    if (!this.running || this.stateValue !== scheduledIn || this.entryCounter !== generation) {
-      return
-    }
-    if (this.flushing) {
-      queueMicrotask(() => this.dispatchAfter(scheduledIn, key, event, generation))
-      return
-    }
+    if (!this.running || this.entryCounter !== generation) return
     const t = this.selectTransition(this.config.states[scheduledIn].after?.[key], event)
-    if (!t) return
-    this.flushing = true
-    try {
-      this.applyTransition(t, event)
-      this.drainQueue()
-    } finally {
-      this.flushing = false
-    }
+    if (t) this.applyTransition(t, event)
   }
 
   private startEffects(state: State, event: Event): void {
@@ -228,7 +211,10 @@ class MachineClass<
     if (after) {
       for (const key in after) {
         const ms = this.resolveDelay(key, event)
-        const id = setTimeout(() => this.dispatchAfter(state, key, event, generation), ms)
+        const id = setTimeout(
+          () => this.enqueue(() => this.dispatchAfter(state, key, event, generation)),
+          ms,
+        )
         this.stateCleanups.push(() => clearTimeout(id))
       }
     }
@@ -289,7 +275,7 @@ class MachineClass<
       // would be re-entrant. The `running` check at job time drops pending runs on stop().
       const off = this.makeSelection(() => source[key]).subscribe(() => {
         this.enqueue(() => {
-          if (this.running) this.runActions(actions, { type: MACHINE_INIT } as Event)
+          if (this.running) this.runActions(actions, INIT_EVENT as Event)
         })
       })
       this.watcherCleanups.push(off)
@@ -306,7 +292,7 @@ class MachineClass<
     this.startWatchers()
     // Boot the CURRENT state's effects — stop() doesn't reset stateValue, so a
     // restart (e.g. StrictMode mount→unmount→mount) may be in any state.
-    this.startEffects(this.stateValue, { type: MACHINE_INIT } as Event)
+    this.startEffects(this.stateValue, INIT_EVENT as Event)
     if (this.startListeners) for (const fn of this.startListeners) fn()
   }
   stop = (): void => {

--- a/packages/core/src/machine.ts
+++ b/packages/core/src/machine.ts
@@ -8,7 +8,6 @@ import { makeSelection } from './selection'
 import { lookupOn, resolve } from './transitions'
 import type {
   Actions,
-  GuardArg,
   Machine,
   Select,
   Selection,
@@ -73,8 +72,8 @@ class MachineClass<
     this.computed = {} as Computed
     if (config.computed) {
       defineComputed(this.computed, config.computed, {
-        context: () => this.ctx,
-        computed: () => this.computed,
+        context: this.ctx,
+        computed: this.computed,
         state: () => this.stateValue,
       })
     }
@@ -82,8 +81,8 @@ class MachineClass<
     this.actionHost = {
       actions: config.implementations?.actions,
       guards: config.implementations?.guards,
-      context: () => this.ctx,
-      computed: () => this.computed,
+      context: this.ctx,
+      computed: this.computed,
       setContext: this.setContext,
       send: this.send,
     }
@@ -117,26 +116,6 @@ class MachineClass<
     this.broadcast.notify()
   }
 
-  // Guard params are built lazily — guardless transitions (the common case) never allocate them.
-  private resolverFor(event: Event): (guard: GuardArg<Context, Event, Computed>) => boolean {
-    let params: ReturnType<typeof makeGuardParams<Context, Event, Computed>> | undefined
-    return guard =>
-      (params ??= makeGuardParams(
-        this.ctx,
-        event,
-        this.computed,
-        this.config.implementations?.guards,
-      )).guard(guard)
-  }
-  // Fast-path: a single guardless object resolves to itself with no resolver or array allocated.
-  private selectTransition(
-    entry: ReturnType<typeof lookupOn<State, Context, Event, Computed>>,
-    event: Event,
-  ): Transition<State, Context, Event, Computed> | undefined {
-    if (entry === undefined) return undefined
-    if (typeof entry === 'object' && !Array.isArray(entry) && !entry.guard) return entry
-    return resolve(entry, this.resolverFor(event))
-  }
   private runActions(actions: Actions<Context, Event, Computed> | undefined, event: Event): void {
     runActions(this.actionHost, actions, event)
   }
@@ -181,7 +160,7 @@ class MachineClass<
         item()
         continue
       }
-      const t = this.selectTransition(lookupOn(this.config, this.stateValue, item.type), item)
+      const t = resolve(lookupOn(this.config, this.stateValue, item.type), item, this.actionHost)
       if (t) this.applyTransition(t, item)
     }
   }
@@ -201,7 +180,7 @@ class MachineClass<
   // Stale when the machine stopped or the state was exited (and maybe re-entered) since scheduling.
   private dispatchAfter(scheduledIn: State, key: string, event: Event, generation: number): void {
     if (!this.running || this.entryCounter !== generation) return
-    const t = this.selectTransition(this.config.states[scheduledIn].after?.[key], event)
+    const t = resolve(this.config.states[scheduledIn].after?.[key], event, this.actionHost)
     if (t) this.applyTransition(t, event)
   }
 

--- a/packages/core/src/transitions.ts
+++ b/packages/core/src/transitions.ts
@@ -1,4 +1,12 @@
-import type { GuardArg, Transition, TransitionConfig, TransitionEntry } from './types'
+import { makeGuardParams } from './guards'
+import type { Guard, GuardParams, Transition, TransitionConfig, TransitionEntry } from './types'
+
+/** What a guard needs to run — the machine's action host satisfies it. */
+export interface GuardHost<Context extends object, Event, Computed> {
+  context: Context
+  computed: Computed
+  guards: Record<string, Guard<Context, Event, Computed>> | undefined
+}
 
 /** Look up the `on` entry for an event: current state first, falling back to `config.on`. */
 export function lookupOn<
@@ -21,19 +29,29 @@ export function lookupOn<
 }
 
 /**
- * Return the first transition whose guard passes. Normalizes the three entry forms
- * (object / bare fn / array) to a list; a bare fn becomes `{ actions: [fn] }` (guardless).
+ * Return the first transition whose guard passes, across the three entry forms
+ * (object / bare fn / array). A bare fn is a guardless `{ actions: fn }`.
+ * Guard params are built once per resolve and only when a guard is met — the
+ * common guardless send allocates nothing here.
  */
 export function resolve<State extends string, Context extends object, Event, Computed>(
   entry: TransitionEntry<State, Context, Event, Computed> | undefined,
-  resolveGuard: (guard: GuardArg<Context, Event, Computed>) => boolean,
+  event: Event,
+  host: GuardHost<Context, Event, Computed>,
 ): Transition<State, Context, Event, Computed> | undefined {
-  if (!entry) return undefined
-  const list = Array.isArray(entry) ? entry : [entry]
-  for (const el of list) {
-    const t: Transition<State, Context, Event, Computed> =
-      typeof el === 'function' ? { actions: [el] } : el
-    if (!t.guard || resolveGuard(t.guard)) return t
+  if (entry === undefined) return undefined
+  if (!Array.isArray(entry)) {
+    if (typeof entry === 'function') return { actions: entry }
+    if (!entry.guard) return entry
+    const params = makeGuardParams(host.context, event, host.computed, host.guards)
+    return params.guard(entry.guard) ? entry : undefined
+  }
+  let params: GuardParams<Context, Event, Computed> | undefined
+  for (const el of entry) {
+    if (typeof el === 'function') return { actions: el }
+    if (!el.guard) return el
+    params ??= makeGuardParams(host.context, event, host.computed, host.guards)
+    if (params.guard(el.guard)) return el
   }
   return undefined
 }


### PR DESCRIPTION
# Why/What

A review pass over the core machine for simpler code and hot-path allocations. Two commits, each with a patch changeset. No behavior change for consumers.

# Changes

**KISS** (`af725ef`)

- `after` timers dispatch through `enqueue` like any send. `dispatchAfter` no longer runs its own copy of the flush cycle, and the `queueMicrotask` branch is gone (a timer cannot fire inside a synchronous drain). The stale check keeps only the entry generation, which already covers "state exited" and "state re-entered".
- `send` and `setContext` are class-field arrows like `start` and `stop`. `doSend` and the `notify` wrapper are removed.
- One frozen `INIT_EVENT` instead of a fresh boot event per use.
- `oneOf` picks its branch with a loop instead of `find`.

**Perf** (`6aa4c3f`)

- `runActions` and `resolve` run a single entry directly, no one-item array wrap per event.
- `resolve` owns all three entry forms and builds guard params only when a guard is met. The per-event resolver closure and the `selectTransition` fast path in the machine are gone.
- Action host and computed host hold the live `ctx` and `computed` objects. No getter call per read, including inside the computed tracking proxies and `stale()`.
- Connector builds the `connect()` argument once. `shallowEqual` compares props with two `for..in` passes instead of two `Object.keys` arrays.

Same-session A/B against the KISS commit:

| Case | Before | After |
|---|---|---|
| Single event | 14.97 M | 16.1 M (+7%) |
| State churn, entry and exit fn | 8.88 M | 9.8 M (+10%) |
| Guards, 8 and 32 candidates | 4.65 M / 3.48 M | 4.8 M / 3.4 M (flat) |

Full suite, typecheck, lint and format pass. Documented benchmark tables are unchanged: the headline rows moved within noise.

Open point for review: the `shallowEqual` rewrite in `connector.ts` is the one change that adds a little subtlety (key counter) without a measured gain. Happy to drop it back to `Object.keys` if you prefer.

# Issues

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)